### PR TITLE
Added IAsyncEnumerable implementations for various API calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,4 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+/.idea

--- a/README.md
+++ b/README.md
@@ -35,17 +35,39 @@ var models = await ollama.ListLocalModels();
 
 ### Pulling a model and reporting progress
 
+#### Callback Syntax
 ```csharp
 await ollama.PullModel("mistral", status => Console.WriteLine($"({status.Percent}%) {status.Status}"));
 ```
 
+#### IAsyncEnumerable Syntax
+```csharp
+await foreach (var status in ollama.PullModel("mistral"))
+{
+    Console.WriteLine($"({status.Percent}%) {status.Status}");
+}
+```
+
 ### Streaming a completion directly into the console
 
+#### Callback Syntax
 ```csharp
 // keep reusing the context to keep the chat topic going
 ConversationContext context = null;
 context = await ollama.StreamCompletion("How are you today?", context, stream => Console.Write(stream.Response));
 ```
+
+#### IAsyncEnumerable Syntax
+```csharp
+// keep reusing the context to keep the chat topic going
+ConversationContext context = null;
+await foreach (var stream in ollama.StreamCompletion("How are you today?", context))
+{
+    Console.Write(stream.Response);
+    context = stream.Context;
+}
+```
+
 
 ### Building interactive chats
 

--- a/src/IOllamaApiClient.cs
+++ b/src/IOllamaApiClient.cs
@@ -171,7 +171,6 @@ namespace OllamaSharp
 		/// Ollama API based on the provided request.
 		/// </summary>
 		/// <param name="request">The request containing the parameters for the completion.</param>
-		/// <param name="streamer">The streamer that receives parts of the completion response as they are streamed by the Ollama endpoint.</param>
 		/// <param name="cancellationToken">The token to cancel the operation with.</param>
 		/// <returns>An asynchronous enumerable of completion response streams.</returns>
 		IAsyncEnumerable<GenerateCompletionResponseStream?> StreamCompletion(GenerateCompletionRequest request, [EnumeratorCancellation] CancellationToken cancellationToken = default);

--- a/src/IOllamaApiClient.cs
+++ b/src/IOllamaApiClient.cs
@@ -1,12 +1,16 @@
 ﻿using OllamaSharp.Models;
 using OllamaSharp.Streamer;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using OllamaSharp.Models.Chat;
 using System.Threading;
 
 namespace OllamaSharp
 {
+	/// <summary>
+	/// Interface for the Ollama API client.
+	/// </summary>
 	public interface IOllamaApiClient
 	{
 		/// <summary>
@@ -43,6 +47,14 @@ namespace OllamaSharp
 		/// </param>
 		/// <param name="cancellationToken">The token to cancel the operation with</param>
 		Task CreateModel(CreateModelRequest request, IResponseStreamer<CreateStatus> streamer, CancellationToken cancellationToken = default);
+
+		/// <summary>
+		/// Sends a request to the /api/create endpoint to create a model
+		/// </summary>
+		/// <param name="request">The request object containing the model details</param>
+		/// <param name="cancellationToken">The token to cancel the operation with</param>
+		/// <returns>An asynchronous enumerable of the model creation status</returns>
+		IAsyncEnumerable<CreateStatus?> CreateModel(CreateModelRequest request, [EnumeratorCancellation] CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Sends a request to the /api/delete endpoint to delete a model
@@ -92,6 +104,14 @@ namespace OllamaSharp
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         Task PullModel(PullModelRequest request, IResponseStreamer<PullStatus> streamer, CancellationToken cancellationToken = default);
 
+        /// <summary>
+        /// Sends a request to the /api/pull endpoint to pull a new model
+        /// </summary>
+        /// <param name="request">The request specifying the model name and whether to use insecure connection</param>
+        /// <param name="cancellationToken">The token to cancel the operation with</param>
+        /// <returns>Async enumerable of PullStatus objects representing the status of the model pull operation</returns>
+        IAsyncEnumerable<PullStatus?> PullModel(PullModelRequest request, [EnumeratorCancellation] CancellationToken cancellationToken = default);
+
 		/// <summary>
 		/// Sends a request to the /api/push endpoint to push a new model
 		/// </summary>
@@ -102,6 +122,15 @@ namespace OllamaSharp
 		/// </param>
 		/// <param name="cancellationToken">The token to cancel the operation with</param>
 		Task PushModel(PushRequest request, IResponseStreamer<PushStatus> streamer, CancellationToken cancellationToken = default);
+
+		/// <summary>
+		/// Pushes a model to the Ollama API endpoint.
+		/// </summary>
+		/// <param name="request">The request containing the model information to push.</param>
+		/// <param name="cancellationToken">The token to cancel the operation with.</param>
+		/// <returns>An asynchronous enumerable of push status updates. Use the enumerator to retrieve the push status updates.</returns>
+		IAsyncEnumerable<PushStatus?> PushModel(PushRequest request,
+			[EnumeratorCancellation] CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Sends a request to the /api/show endpoint to show the information of a model
@@ -127,6 +156,16 @@ namespace OllamaSharp
 		/// </returns>
 		Task<ConversationContext> StreamCompletion(GenerateCompletionRequest request, IResponseStreamer<GenerateCompletionResponseStream> streamer, CancellationToken cancellationToken = default);
 
+		/// <summary>
+		/// Streams completion responses from the /api/generate endpoint on the
+		/// Ollama API based on the provided request.
+		/// </summary>
+		/// <param name="request">The request containing the parameters for the completion.</param>
+		/// <param name="streamer">The streamer that receives parts of the completion response as they are streamed by the Ollama endpoint.</param>
+		/// <param name="cancellationToken">The token to cancel the operation with.</param>
+		/// <returns>An asynchronous enumerable of completion response streams.</returns>
+		IAsyncEnumerable<GenerateCompletionResponseStream?> StreamCompletion(GenerateCompletionRequest request, [EnumeratorCancellation] CancellationToken cancellationToken = default);
+		
 		/// <summary>
 		/// Sends a query to check whether the Ollama api is running or not
 		/// </summary>

--- a/src/IOllamaApiClient.cs
+++ b/src/IOllamaApiClient.cs
@@ -31,6 +31,16 @@ namespace OllamaSharp
 		Task<IEnumerable<Message>> SendChat(ChatRequest chatRequest, IResponseStreamer<ChatResponseStream> streamer, CancellationToken cancellationToken = default);
 
 		/// <summary>
+		/// Sends a request to the /api/chat endpoint and streams the response of the chat.
+		/// </summary>
+		/// <param name="chatRequest">The request to send to Ollama</param>
+		/// <param name="cancellationToken">The token to cancel the operation with</param>
+		/// <returns>
+		/// An asynchronous enumerable that yields ChatResponseStream. Each item represents a message in the chat response stream.
+		/// Returns null when the stream is completed.</returns>
+		IAsyncEnumerable<ChatResponseStream?> StreamChat(ChatRequest chatRequest, [EnumeratorCancellation] CancellationToken cancellationToken = default);
+		
+		/// <summary>
 		/// Sends a request to the /api/copy endpoint to copy a model
 		/// </summary>
 		/// <param name="request">The parameters required to copy a model</param>

--- a/src/OllamaApiClientExtensions.cs
+++ b/src/OllamaApiClientExtensions.cs
@@ -54,9 +54,9 @@ namespace OllamaSharp
 		/// </param>
 		/// <param name="cancellationToken">The token to cancel the operation with</param>
 		/// <returns>List of the returned messages including the previous context</returns>
-		public static async Task<IEnumerable<Message>> SendChat(this IOllamaApiClient client, ChatRequest chatRequest, Action<ChatResponseStream> streamer, CancellationToken cancellationToken = default)
+		public static async Task<IEnumerable<Message>> SendChat(this IOllamaApiClient client, ChatRequest chatRequest, Action<ChatResponseStream?> streamer, CancellationToken cancellationToken = default)
 		{
-			return await client.SendChat(chatRequest, new ActionResponseStreamer<ChatResponseStream>(streamer), cancellationToken);
+			return await client.SendChat(chatRequest, new ActionResponseStreamer<ChatResponseStream?>(streamer), cancellationToken);
 		}
 
 		/// <summary>
@@ -271,6 +271,24 @@ namespace OllamaSharp
 			};
 
 			return await client.StreamCompletion(request, new ActionResponseStreamer<GenerateCompletionResponseStream>(streamer), cancellationToken);
+		}
+
+		public static IAsyncEnumerable<GenerateCompletionResponseStream?>
+			StreamCompletion(
+				this IOllamaApiClient client,
+				string prompt,
+				ConversationContext context,
+				CancellationToken cancellationToken = default)
+		{
+			var request = new GenerateCompletionRequest
+			{
+				Prompt = prompt,
+				Model = client.SelectedModel,
+				Stream = true,
+				Context = context?.Context ?? Array.Empty<long>()
+			};
+			
+			return client.StreamCompletion(request, cancellationToken);
 		}
 	}
 }

--- a/src/OllamaSharp.csproj
+++ b/src/OllamaSharp.csproj
@@ -35,6 +35,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
 		<PackageReference Include="System.Text.Json" Version="8.0.2" />
 	</ItemGroup>
 </Project>

--- a/test/TestOllamaApiClient.cs
+++ b/test/TestOllamaApiClient.cs
@@ -98,4 +98,28 @@ public class TestOllamaApiClient : IOllamaApiClient
 	}
 
 	public Task<bool> IsRunning(CancellationToken cancellationToken = default) => Task.FromResult(true);
+	public IAsyncEnumerable<CreateStatus?> CreateModel(CreateModelRequest request, CancellationToken cancellationToken = default)
+	{
+		throw new NotImplementedException();
+	}
+
+	public IAsyncEnumerable<PullStatus?> PullModel(PullModelRequest request, CancellationToken cancellationToken = default)
+	{
+		throw new NotImplementedException();
+	}
+
+	public IAsyncEnumerable<PushStatus?> PushModel(PushRequest request, CancellationToken cancellationToken = default)
+	{
+		throw new NotImplementedException();
+	}
+
+	public IAsyncEnumerable<GenerateCompletionResponseStream?> StreamCompletion(GenerateCompletionRequest request, CancellationToken cancellationToken = default)
+	{
+		throw new NotImplementedException();
+	}
+
+	public IAsyncEnumerable<ChatResponseStream?> StreamChat(ChatRequest chatRequest, CancellationToken cancellationToken = default)
+	{
+		throw new NotImplementedException();
+	}
 }


### PR DESCRIPTION
Implemented a new syntax leveraging `IAsyncEnumerable` to let users choose between callbacks and stream enumerations.

The new calls allowing for `IAsyncEnumerable` instead of an action callback are:
```csharp
IAsyncEnumerable<CreateStatus?> CreateModel(CreateModelRequest request, [EnumeratorCancellation] CancellationToken cancellationToken = default);

IAsyncEnumerable<PullStatus?> PullModel(PullModelRequest request, [EnumeratorCancellation] CancellationToken cancellationToken = default);

IAsyncEnumerable<PushStatus?> PushModel(PushRequest request, [EnumeratorCancellation] CancellationToken cancellationToken = default);

IAsyncEnumerable<ChatResponseStream?> StreamChat(ChatRequest chatRequest, [EnumeratorCancellation] CancellationToken cancellationToken = default)

IAsyncEnumerable<GenerateCompletionResponseStream?> StreamCompletion(GenerateCompletionRequest request, [EnumeratorCancellation] CancellationToken cancellationToken = default);
```