### PR TITLE
Add Chat With Metadata Endpoint to OllamaSharp client

### DIFF
--- a/OllamaSharp.sln
+++ b/OllamaSharp.sln
@@ -7,7 +7,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OllamaSharp", "src\OllamaSh
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tests", "test\Tests.csproj", "{1527F300-40C7-49EB-A6FD-D21B20BA5BC1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OllamaApiConsole", "OllamaApiConsole\OllamaApiConsole.csproj", "{81DCD129-2666-4846-8D3F-8682F6276289}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OllamaApiConsole", "OllamaApiConsole\OllamaApiConsole.csproj", "{81DCD129-2666-4846-8D3F-8682F6276289}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{7B88E967-DA41-4A3F-80B9-AAAE0A7B471D}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/IOllamaApiClient.cs
+++ b/src/IOllamaApiClient.cs
@@ -24,6 +24,16 @@ public interface IOllamaApiClient
 	/// Sends a request to the /api/chat endpoint
 	/// </summary>
 	/// <param name="chatRequest">The request to send to Ollama</param>
+	/// <param name="cancellationToken">The token to cancel the operation with</param>
+	/// <returns>The returned message with metadata</returns>
+	Task<ChatResponse> Chat(
+		ChatRequest chatRequest,
+		CancellationToken cancellationToken = default);
+
+	/// <summary>
+	/// Sends a request to the /api/chat endpoint
+	/// </summary>
+	/// <param name="chatRequest">The request to send to Ollama</param>
 	/// <param name="streamer">
 	/// The streamer that receives parts of the answer as they are streamed
 	/// by the Ollama endpoint. Can be used to update the user interface while

--- a/src/Models/Chat/ChatResponse.cs
+++ b/src/Models/Chat/ChatResponse.cs
@@ -1,0 +1,72 @@
+using System.Text.Json.Serialization;
+
+namespace OllamaSharp.Models.Chat;
+
+public class ChatResponse
+{
+	/// <summary>
+	/// The model that generated the response
+	/// </summary>
+	[JsonPropertyName("model")]
+	public string Model { get; set; } = null!;
+
+	/// <summary>
+	/// The time the response was generated
+	/// </summary>
+	[JsonPropertyName("created_at")]
+	public string CreatedAt { get; set; } = null!;
+
+	/// <summary>
+	/// The message returned by the model
+	/// </summary>
+	[JsonPropertyName("message")]
+	public Message Message { get; set; } = null!;
+
+	/// <summary>
+	/// Whether the response is complete
+	/// </summary>
+	[JsonPropertyName("done")]
+	public bool Done { get; set; }
+
+	/// <summary>
+	/// The reason for the completion of the chat
+	/// </summary>
+	[JsonPropertyName("done_reason")]
+	public string? DoneReason { get; set; }
+
+	/// <summary>
+	/// The time spent generating the response
+	/// </summary>
+	[JsonPropertyName("total_duration")]
+	public long TotalDuration { get; set; }
+
+	/// <summary>
+	/// The time spent in nanoseconds loading the model
+	/// </summary>
+	[JsonPropertyName("load_duration")]
+	public long LoadDuration { get; set; }
+
+	/// <summary>
+	/// The number of tokens in the prompt
+	/// </summary>
+	[JsonPropertyName("prompt_eval_count")]
+	public int PromptEvalCount { get; set; }
+
+	/// <summary>
+	/// The time spent in nanoseconds evaluating the prompt
+	/// </summary>
+	[JsonPropertyName("prompt_eval_duration")]
+	public long PromptEvalDuration { get; set; }
+
+	/// <summary>
+	/// The number of tokens in the response
+	/// </summary>
+	[JsonPropertyName("eval_count")]
+	public int EvalCount { get; set; }
+
+	/// <summary>
+	/// The time in nanoseconds spent generating the response
+	/// </summary>
+	[JsonPropertyName("eval_duration")]
+	public long EvalDuration { get; set; }
+}

--- a/test/TestOllamaApiClient.cs
+++ b/test/TestOllamaApiClient.cs
@@ -127,4 +127,9 @@ public class TestOllamaApiClient : IOllamaApiClient
 	{
 		throw new NotImplementedException();
 	}
+
+	public Task<ChatResponse> Chat(ChatRequest chatRequest, CancellationToken cancellationToken = default)
+	{
+		throw new NotImplementedException();
+	}
 }


### PR DESCRIPTION
When implementing Ollama Connector in Semantic Kernel was evident that lack of support for providing metadata when using the non-streaming chat endpoint as well as the different behavior of the Chat endpoint returning a list of messages including the original chathistory, different from the format received from the underlying API.

This change introduces the `Chat` method following the name `StreamChat` for non-streaming requests.