### PR TITLE
Fix tool chat console demo

### DIFF
--- a/OllamaApiConsole/Demos/ToolConsole.cs
+++ b/OllamaApiConsole/Demos/ToolConsole.cs
@@ -97,7 +97,7 @@ public class ToolConsole(IOllamaApiClient ollama) : OllamaConsole(ollama)
 						["location"] = new Properties { Type = "string", Description = "The location to get the weather for, e.g. San Francisco, CA" },
 						["format"] = new Properties { Type = "string", Description = "The format to return the weather in, e.g. 'celsius' or 'fahrenheit'", Enum = ["celsius", "fahrenheit"] },
 					},
-					Required = ["location", "fahrenheit"],
+					Required = ["location", "format"],
 				}
 			};
 			Type = "function";

--- a/src/Models/Chat/MessageBuilder.cs
+++ b/src/Models/Chat/MessageBuilder.cs
@@ -61,5 +61,5 @@ public class MessageBuilder
 	/// <summary>
 	/// Gets whether the message builder received message chunks yet
 	/// </summary>
-	public bool HasValue => _contentBuilder.Length > 0;
+	public bool HasValue => _contentBuilder.Length > 0 || ToolCalls.Count > 0;
 }


### PR DESCRIPTION
I just tried out the **tool chat console demo** and received the following error:
`The JSON value could not be converted to System.String. Path: $.message.tool_calls[[0]].function.arguments.fahrenheit | LineNumber: 0 | BytePositionInLine: 203.`

I noticed that the "required"-field in the function definition seemed off, since it was set to "fahrenheit".
According to the [function calling API documentation of OpenAPI ](https://platform.openai.com/docs/guides/function-calling/step-2-describe-your-function-to-the-model-so-it-knows-how-to-call-it) this should be a property name, which is why I changed it to "format" instead.

I also noticed that the tool call is ignored since the MessageBuilders "HasValue" function ignores the ToolCalls and changed it accordingly.
I am not sure whether the Image list has to be added there too.

After those changes, the demo worked perfectly. It also worked with multiple function calls in one prompt.

Thanks for this library!
