### PR TITLE
Allow custom http request headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ OllamaSharp provides .NET bindings for the [Ollama API](https://github.com/jmorg
 
 OllamaSharp wraps every Ollama API endpoint in awaitable methods that fully support response streaming.
 
-The following list shows a few examples to get a glimpse on how easy it is to use. The list is not complete.
+The following list shows a few simple code examples.
+
+ℹ **Try our full-featured Ollama API client app [OllamaSharpConsole](https://github.com/awaescher/OllamaSharpConsole) to interact with your Ollama instance.**
 
 ### Initializing
 

--- a/src/HttpRequestMessageExtensions.cs
+++ b/src/HttpRequestMessageExtensions.cs
@@ -1,0 +1,28 @@
+using System.Net.Http;
+using OllamaSharp.Models;
+
+namespace OllamaSharp;
+
+/// <summary>
+/// Extension methods for the http request message
+/// </summary>
+public static class HttpRequestMessageExtensions
+{
+	/// <summary>
+	/// Applies default headers from the OllamaApiClient and optional Ollama requests
+	/// </summary>
+	/// <param name="requestMessage">The http request message to set the headers on</param>
+	/// <param name="apiClient">The OllamaApiClient get the default request headers from</param>
+	/// <param name="ollamaRequest">The request to the Ollama API to get the custom headers from</param>
+	public static void ApplyCustomHeaders(this HttpRequestMessage requestMessage, OllamaApiClient apiClient, OllamaRequest? ollamaRequest)
+	{
+		foreach (var header in apiClient.DefaultRequestHeaders)
+			requestMessage.Headers.Add(header.Key, header.Value);
+
+		if (ollamaRequest != null)
+		{
+			foreach (var header in ollamaRequest.CustomHeaders)
+				requestMessage.Headers.Add(header.Key, header.Value);
+		}
+	}
+}

--- a/src/HttpRequestMessageExtensions.cs
+++ b/src/HttpRequestMessageExtensions.cs
@@ -17,12 +17,20 @@ public static class HttpRequestMessageExtensions
 	public static void ApplyCustomHeaders(this HttpRequestMessage requestMessage, OllamaApiClient apiClient, OllamaRequest? ollamaRequest)
 	{
 		foreach (var header in apiClient.DefaultRequestHeaders)
-			requestMessage.Headers.Add(header.Key, header.Value);
+			AddOrUpdateHeaderValue(requestMessage.Headers, header.Key, header.Value);
 
 		if (ollamaRequest != null)
 		{
 			foreach (var header in ollamaRequest.CustomHeaders)
-				requestMessage.Headers.Add(header.Key, header.Value);
+				AddOrUpdateHeaderValue(requestMessage.Headers, header.Key, header.Value);
 		}
+	}
+
+	private static void AddOrUpdateHeaderValue(System.Net.Http.Headers.HttpRequestHeaders requestMessageHeaders, string headerKey, string headerValue)
+	{
+		if (requestMessageHeaders.Contains(headerKey))
+			requestMessageHeaders.Remove(headerKey);
+
+		requestMessageHeaders.Add(headerKey, headerValue);
 	}
 }

--- a/src/IOllamaApiClient.cs
+++ b/src/IOllamaApiClient.cs
@@ -24,7 +24,7 @@ public interface IOllamaApiClient
 	/// Sends a request to the /api/chat endpoint and streams the response of the chat.
 	/// To implement a fully interactive chat, you should make use of the Chat class with "new Chat(...)"
 	/// </summary>
-	/// <param name="chatRequest">The request to send to Ollama</param>
+	/// <param name="request">The request to send to Ollama</param>
 	/// <param name="cancellationToken">The token to cancel the operation with</param>
 	/// <returns>
 	/// An asynchronous enumerable that yields ChatResponseStream. Each item
@@ -35,7 +35,7 @@ public interface IOllamaApiClient
 	/// This is the method to call the Ollama endpoint /api/chat. You might not want to do this manually.
 	/// To implement a fully interactive chat, you should make use of the Chat class with "new Chat(...)"
 	/// </remarks>
-	IAsyncEnumerable<ChatResponseStream?> Chat(ChatRequest chatRequest, [EnumeratorCancellation] CancellationToken cancellationToken = default);
+	IAsyncEnumerable<ChatResponseStream?> Chat(ChatRequest request, [EnumeratorCancellation] CancellationToken cancellationToken = default);
 
 	/// <summary>
 	/// Sends a request to the /api/copy endpoint to copy a model
@@ -55,9 +55,9 @@ public interface IOllamaApiClient
 	/// <summary>
 	/// Sends a request to the /api/delete endpoint to delete a model
 	/// </summary>
-	/// <param name="model">The name of the model to delete</param>
+	/// <param name="request">The request containing the model to delete</param>
 	/// <param name="cancellationToken">The token to cancel the operation with</param>
-	Task DeleteModel(string model, CancellationToken cancellationToken = default);
+	Task DeleteModel(DeleteModelRequest request, CancellationToken cancellationToken = default);
 
 	/// <summary>
 	/// Sends a request to the /api/embed endpoint to generate embeddings
@@ -67,8 +67,7 @@ public interface IOllamaApiClient
 	Task<EmbedResponse> Embed(EmbedRequest request, CancellationToken cancellationToken = default);
 
 	/// <summary>
-	/// Sends a request to the /api/tags endpoint to get all models that are
-	/// available locally
+	/// Sends a request to the /api/tags endpoint to get all models that are available locally
 	/// </summary>
 	/// <param name="cancellationToken">The token to cancel the operation with</param>
 	Task<IEnumerable<Model>> ListLocalModels(CancellationToken cancellationToken = default);
@@ -82,8 +81,7 @@ public interface IOllamaApiClient
 	/// <summary>
 	/// Sends a request to the /api/pull endpoint to pull a new model
 	/// </summary>
-	/// <param name="request">The request specifying the model name and whether
-	/// to use insecure connection</param>
+	/// <param name="request">The request specifying the model name and whether to use insecure connection</param>
 	/// <param name="cancellationToken">The token to cancel the operation with</param>
 	/// <returns>
 	/// Async enumerable of PullStatus objects representing the status of the
@@ -94,27 +92,24 @@ public interface IOllamaApiClient
 	/// <summary>
 	/// Pushes a model to the Ollama API endpoint.
 	/// </summary>
-	/// <param name="modelRequest">The request containing the model information to
-	/// push.</param>
+	/// <param name="request">The request containing the model information to push.</param>
 	/// <param name="cancellationToken">The token to cancel the operation with.</param>
 	/// <returns>
 	/// An asynchronous enumerable of push status updates. Use the enumerator
 	/// to retrieve the push status updates.
 	/// </returns>
-	IAsyncEnumerable<PushModelResponse?> PushModel(PushModelRequest modelRequest, [EnumeratorCancellation] CancellationToken cancellationToken = default);
+	IAsyncEnumerable<PushModelResponse?> PushModel(PushModelRequest request, [EnumeratorCancellation] CancellationToken cancellationToken = default);
 
 	/// <summary>
-	/// Sends a request to the /api/show endpoint to show the information of a
-	/// model
+	/// Sends a request to the /api/show endpoint to show the information of a model
 	/// </summary>
-	/// <param name="model">The name of the model the get the information for</param>
+	/// <param name="request">The request containing the name of the model the get the information for</param>
 	/// <param name="cancellationToken">The token to cancel the operation with</param>
 	/// <returns>The model information</returns>
-	Task<ShowModelResponse> ShowModel(string model, CancellationToken cancellationToken = default);
+	Task<ShowModelResponse> ShowModel(ShowModelRequest request, CancellationToken cancellationToken = default);
 
 	/// <summary>
-	/// Streams completion responses from the /api/generate endpoint on the
-	/// Ollama API based on the provided request.
+	/// Streams completion responses from the /api/generate endpoint on the Ollama API based on the provided request.
 	/// </summary>
 	/// <param name="request">The request containing the parameters for the completion.</param>
 	/// <param name="cancellationToken">The token to cancel the operation with.</param>

--- a/src/Models/Chat/ChatRequest.cs
+++ b/src/Models/Chat/ChatRequest.cs
@@ -7,7 +7,7 @@ namespace OllamaSharp.Models.Chat;
 /// <summary>
 /// https://github.com/jmorganca/ollama/blob/main/docs/api.md#generate-a-chat-completion
 /// </summary>
-public class ChatRequest
+public class ChatRequest : OllamaRequest
 {
 	/// <summary>
 	/// The model name (required)

--- a/src/Models/CopyModel.cs
+++ b/src/Models/CopyModel.cs
@@ -5,7 +5,7 @@ namespace OllamaSharp.Models;
 /// <summary>
 /// https://github.com/jmorganca/ollama/blob/main/docs/api.md#copy-a-model
 /// </summary>
-public class CopyModelRequest
+public class CopyModelRequest : OllamaRequest
 {
 	/// <summary>
 	/// The source model name

--- a/src/Models/CreateModel.cs
+++ b/src/Models/CreateModel.cs
@@ -6,7 +6,7 @@ namespace OllamaSharp.Models;
 /// https://github.com/jmorganca/ollama/blob/main/docs/api.md#create-a-model
 /// </summary>
 [JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Skip)]
-public class CreateModelRequest
+public class CreateModelRequest : OllamaRequest
 {
 	/// <summary>
 	/// Name of the model to create

--- a/src/Models/DeleteModel.cs
+++ b/src/Models/DeleteModel.cs
@@ -6,7 +6,7 @@ namespace OllamaSharp.Models;
 /// https://github.com/jmorganca/ollama/blob/main/docs/api.md#delete-a-model
 /// </summary>
 [JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Skip)]
-public class DeleteModelRequest
+public class DeleteModelRequest : OllamaRequest
 {
 	/// <summary>
 	/// The name of the model to delete

--- a/src/Models/Embed.cs
+++ b/src/Models/Embed.cs
@@ -6,7 +6,7 @@ namespace OllamaSharp.Models;
 /// <summary>
 /// https://github.com/jmorganca/ollama/blob/main/docs/api.md#generate-embeddings
 /// </summary>
-public class EmbedRequest
+public class EmbedRequest : OllamaRequest
 {
 	/// <summary>
 	/// The name of the model to generate embeddings from

--- a/src/Models/Generate.cs
+++ b/src/Models/Generate.cs
@@ -5,7 +5,7 @@ namespace OllamaSharp.Models;
 /// <summary>
 /// https://github.com/jmorganca/ollama/blob/main/docs/api.md#generate-a-completion
 /// </summary>
-public class GenerateRequest
+public class GenerateRequest : OllamaRequest
 {
 	/// <summary>
 	/// The model name (required)

--- a/src/Models/OllamaRequest.cs
+++ b/src/Models/OllamaRequest.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace OllamaSharp.Models;
+
+/// <summary>
+/// Base class for requests to Ollama
+/// </summary>
+public abstract class OllamaRequest
+{
+	public Dictionary<string, string> CustomHeaders { get; } = new();
+}

--- a/src/Models/PullModel.cs
+++ b/src/Models/PullModel.cs
@@ -5,7 +5,7 @@ namespace OllamaSharp.Models;
 /// <summary>
 /// https://github.com/jmorganca/ollama/blob/main/docs/api.md#pull-a-model
 /// </summary>
-public class PullModelRequest
+public class PullModelRequest : OllamaRequest
 {
 	/// <summary>
 	/// The name of the model to pull in the form of <namespace>/<model>:<tag>

--- a/src/Models/PushModel.cs
+++ b/src/Models/PushModel.cs
@@ -5,7 +5,7 @@ namespace OllamaSharp.Models;
 /// <summary>
 /// https://github.com/jmorganca/ollama/blob/main/docs/api.md#push-a-model
 /// </summary>
-public class PushModelRequest
+public class PushModelRequest : OllamaRequest
 {
 	/// <summary>
 	/// Name of the model to push in the form of <namespace>/<model>:<tag>

--- a/src/Models/ShowModel.cs
+++ b/src/Models/ShowModel.cs
@@ -7,7 +7,7 @@ namespace OllamaSharp.Models;
 /// https://github.com/jmorganca/ollama/blob/main/docs/api.md#show-model-information
 /// </summary>
 [JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Skip)]
-public class ShowModelRequest
+public class ShowModelRequest : OllamaRequest
 {
 	/// <summary>
 	///  The name of the model to show

--- a/src/OllamaApiClient.cs
+++ b/src/OllamaApiClient.cs
@@ -30,7 +30,7 @@ public class OllamaApiClient : IOllamaApiClient
 	/// Gets the serializer options for outgoing web requests like Post or Delete
 	/// </summary>
 	public JsonSerializerOptions OutgoingJsonSerializerOptions { get; } = new() { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
-	
+
 	/// <summary>
 	/// Gets the serializer options used for deserializing http responses.
 	/// </summary>

--- a/src/OllamaApiClient.cs
+++ b/src/OllamaApiClient.cs
@@ -22,11 +22,15 @@ namespace OllamaSharp;
 public class OllamaApiClient : IOllamaApiClient
 {
 	/// <summary>
+	/// Gets the default request headers that are sent to the Ollama API
+	/// </summary>
+	public Dictionary<string, string> DefaultRequestHeaders { get; } = new();
+
+	/// <summary>
 	/// Gets the serializer options for outgoing web requests like Post or Delete
 	/// </summary>
 	public JsonSerializerOptions OutgoingJsonSerializerOptions { get; } = new() { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
 
-	private readonly HttpClient _client;
 
 	/// <summary>
 	/// Gets the current configuration of the API client
@@ -35,6 +39,11 @@ public class OllamaApiClient : IOllamaApiClient
 
 	/// <inheritdoc />
 	public string SelectedModel { get; set; }
+
+	/// <summary>
+	/// Gets the http client that is used to communicate with the Ollama API
+	/// </summary>
+	private readonly HttpClient _client;
 
 	/// <summary>
 	/// Creates a new instace of the Ollama API client
@@ -90,16 +99,14 @@ public class OllamaApiClient : IOllamaApiClient
 	}
 
 	/// <inheritdoc />
-	public async Task DeleteModel(string model, CancellationToken cancellationToken = default)
+	public async Task DeleteModel(DeleteModelRequest request, CancellationToken cancellationToken = default)
 	{
-		var request = new HttpRequestMessage(HttpMethod.Delete, "api/delete")
+		var requestMessage = new HttpRequestMessage(HttpMethod.Delete, "api/delete")
 		{
-			Content = new StringContent(JsonSerializer.Serialize(new DeleteModelRequest { Model = model }, OutgoingJsonSerializerOptions), Encoding.UTF8, "application/json")
+			Content = new StringContent(JsonSerializer.Serialize(request, OutgoingJsonSerializerOptions), Encoding.UTF8, "application/json")
 		};
 
-		using var response = await _client.SendAsync(request, cancellationToken);
-
-		await EnsureSuccessStatusCode(response);
+		await SendToOllamaAsync(requestMessage, request, HttpCompletionOption.ResponseContentRead, cancellationToken);
 	}
 
 	/// <inheritdoc />
@@ -117,8 +124,8 @@ public class OllamaApiClient : IOllamaApiClient
 	}
 
 	/// <inheritdoc />
-	public Task<ShowModelResponse> ShowModel(string model, CancellationToken cancellationToken = default)
-		=> PostAsync<ShowModelRequest, ShowModelResponse>("api/show", new ShowModelRequest { Model = model }, cancellationToken);
+	public Task<ShowModelResponse> ShowModel(ShowModelRequest request, CancellationToken cancellationToken = default)
+		=> PostAsync<ShowModelRequest, ShowModelResponse>("api/show", request, cancellationToken);
 
 	/// <inheritdoc />
 	public Task CopyModel(CopyModelRequest request, CancellationToken cancellationToken = default)
@@ -132,10 +139,9 @@ public class OllamaApiClient : IOllamaApiClient
 	}
 
 	/// <inheritdoc />
-	public async IAsyncEnumerable<PushModelResponse?> PushModel(PushModelRequest modelRequest, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+	public async IAsyncEnumerable<PushModelResponse?> PushModel(PushModelRequest request, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 	{
-		var stream = StreamPostAsync<PushModelRequest, PushModelResponse?>(
-			"api/push", modelRequest, cancellationToken);
+		var stream = StreamPostAsync<PushModelRequest, PushModelResponse?>("api/push", request, cancellationToken);
 
 		await foreach (var result in stream)
 			yield return result;
@@ -153,20 +159,18 @@ public class OllamaApiClient : IOllamaApiClient
 	}
 
 	/// <inheritdoc />
-	public async IAsyncEnumerable<ChatResponseStream?> Chat(ChatRequest chatRequest, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+	public async IAsyncEnumerable<ChatResponseStream?> Chat(ChatRequest request, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 	{
-		var request = new HttpRequestMessage(HttpMethod.Post, "api/chat")
+		var requestMessage = new HttpRequestMessage(HttpMethod.Post, "api/chat")
 		{
-			Content = new StringContent(JsonSerializer.Serialize(chatRequest, OutgoingJsonSerializerOptions), Encoding.UTF8, "application/json")
+			Content = new StringContent(JsonSerializer.Serialize(request, OutgoingJsonSerializerOptions), Encoding.UTF8, "application/json")
 		};
 
-		var completion = chatRequest.Stream
+		var completion = request.Stream
 			? HttpCompletionOption.ResponseHeadersRead
 			: HttpCompletionOption.ResponseContentRead;
 
-		using var response = await _client.SendAsync(request, completion, cancellationToken);
-
-		await EnsureSuccessStatusCode(response);
+		using var response = await SendToOllamaAsync(requestMessage, request, completion, cancellationToken);
 
 		await foreach (var result in ProcessStreamedChatResponseAsync(response, cancellationToken))
 			yield return result;
@@ -175,9 +179,12 @@ public class OllamaApiClient : IOllamaApiClient
 	/// <inheritdoc />
 	public async Task<bool> IsRunning(CancellationToken cancellationToken = default)
 	{
-		var response = await _client.GetAsync("", cancellationToken); // without route returns "Ollama is running"
-		await EnsureSuccessStatusCode(response);
+		var requestMessage = new HttpRequestMessage(HttpMethod.Get, ""); // without route returns "Ollama is running"
+
+		using var response = await SendToOllamaAsync(requestMessage, null, HttpCompletionOption.ResponseContentRead, cancellationToken);
+
 		var stringContent = await response.Content.ReadAsStringAsync();
+
 		return !string.IsNullOrWhiteSpace(stringContent);
 	}
 
@@ -190,7 +197,7 @@ public class OllamaApiClient : IOllamaApiClient
 
 	private async IAsyncEnumerable<GenerateResponseStream?> GenerateCompletion(GenerateRequest generateRequest, [EnumeratorCancellation] CancellationToken cancellationToken)
 	{
-		var request = new HttpRequestMessage(HttpMethod.Post, "api/generate")
+		var requestMessage = new HttpRequestMessage(HttpMethod.Post, "api/generate")
 		{
 			Content = new StringContent(JsonSerializer.Serialize(generateRequest, OutgoingJsonSerializerOptions), Encoding.UTF8, "application/json")
 		};
@@ -199,9 +206,7 @@ public class OllamaApiClient : IOllamaApiClient
 			? HttpCompletionOption.ResponseHeadersRead
 			: HttpCompletionOption.ResponseContentRead;
 
-		using var response = await _client.SendAsync(request, completion, cancellationToken);
-
-		await EnsureSuccessStatusCode(response);
+		using var response = await SendToOllamaAsync(requestMessage, generateRequest, completion, cancellationToken);
 
 		await foreach (var result in ProcessStreamedCompletionResponseAsync(response, cancellationToken))
 			yield return result;
@@ -209,45 +214,47 @@ public class OllamaApiClient : IOllamaApiClient
 
 	private async Task<TResponse> GetAsync<TResponse>(string endpoint, CancellationToken cancellationToken)
 	{
-		var response = await _client.GetAsync(endpoint, cancellationToken);
+		var requestMessage = new HttpRequestMessage(HttpMethod.Get, endpoint);
 
-		await EnsureSuccessStatusCode(response);
-
-		var responseBody = await response.Content.ReadAsStringAsync();
-
-		return JsonSerializer.Deserialize<TResponse>(responseBody)!;
-	}
-
-	private async Task PostAsync<TRequest>(string endpoint, TRequest request, CancellationToken cancellationToken)
-	{
-		var content = new StringContent(JsonSerializer.Serialize(request, OutgoingJsonSerializerOptions), Encoding.UTF8, "application/json");
-		var response = await _client.PostAsync(endpoint, content, cancellationToken);
-
-		await EnsureSuccessStatusCode(response);
-	}
-
-	private async Task<TResponse> PostAsync<TRequest, TResponse>(string endpoint, TRequest request, CancellationToken cancellationToken)
-	{
-		var content = new StringContent(JsonSerializer.Serialize(request, OutgoingJsonSerializerOptions), Encoding.UTF8, "application/json");
-		var response = await _client.PostAsync(endpoint, content, cancellationToken);
-
-		await EnsureSuccessStatusCode(response);
+		using var response = await SendToOllamaAsync(requestMessage, null, HttpCompletionOption.ResponseContentRead, cancellationToken);
 
 		var responseBody = await response.Content.ReadAsStringAsync();
 
 		return JsonSerializer.Deserialize<TResponse>(responseBody)!;
 	}
 
-	private async IAsyncEnumerable<TResponse?> StreamPostAsync<TRequest, TResponse>(string endpoint, TRequest requestModel, [EnumeratorCancellation] CancellationToken cancellationToken)
+	private async Task PostAsync<TRequest>(string endpoint, TRequest ollamaRequest, CancellationToken cancellationToken) where TRequest : OllamaRequest
 	{
-		var request = new HttpRequestMessage(HttpMethod.Post, endpoint)
+		var requestMessage = new HttpRequestMessage(HttpMethod.Post, endpoint)
 		{
-			Content = new StringContent(JsonSerializer.Serialize(requestModel, OutgoingJsonSerializerOptions), Encoding.UTF8, "application/json")
+			Content = new StringContent(JsonSerializer.Serialize(ollamaRequest, OutgoingJsonSerializerOptions), Encoding.UTF8, "application/json")
 		};
 
-		using var response = await _client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+		await SendToOllamaAsync(requestMessage, ollamaRequest, HttpCompletionOption.ResponseContentRead, cancellationToken);
+	}
 
-		await EnsureSuccessStatusCode(response);
+	private async Task<TResponse> PostAsync<TRequest, TResponse>(string endpoint, TRequest ollamaRequest, CancellationToken cancellationToken) where TRequest : OllamaRequest
+	{
+		var requestMessage = new HttpRequestMessage(HttpMethod.Post, endpoint)
+		{
+			Content = new StringContent(JsonSerializer.Serialize(ollamaRequest, OutgoingJsonSerializerOptions), Encoding.UTF8, "application/json")
+		};
+
+		using var response = await SendToOllamaAsync(requestMessage, ollamaRequest, HttpCompletionOption.ResponseContentRead, cancellationToken);
+
+		var responseBody = await response.Content.ReadAsStringAsync();
+
+		return JsonSerializer.Deserialize<TResponse>(responseBody)!;
+	}
+
+	private async IAsyncEnumerable<TResponse?> StreamPostAsync<TRequest, TResponse>(string endpoint, TRequest ollamaRequest, [EnumeratorCancellation] CancellationToken cancellationToken) where TRequest : OllamaRequest
+	{
+		var requestMessage = new HttpRequestMessage(HttpMethod.Post, endpoint)
+		{
+			Content = new StringContent(JsonSerializer.Serialize(ollamaRequest, OutgoingJsonSerializerOptions), Encoding.UTF8, "application/json")
+		};
+
+		using var response = await SendToOllamaAsync(requestMessage, ollamaRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
 
 		await foreach (var result in ProcessStreamedResponseAsync<TResponse>(response, cancellationToken))
 			yield return result;
@@ -295,6 +302,24 @@ public class OllamaApiClient : IOllamaApiClient
 				? JsonSerializer.Deserialize<ChatDoneResponseStream>(line)!
 				: streamedResponse;
 		}
+	}
+
+	/// <summary>
+	/// Sends a http request message to the Ollama API.
+	/// </summary>
+	/// <param name="requestMessage">The http request message to send</param>
+	/// <param name="ollamaRequest">The request containing custom http request headers</param>
+	/// <param name="completionOption">When the operation should complete (as soon as a response is available or after reading the whole respose content)</param>
+	/// <param name="cancellationToken">The token to cancel the operation with</param>
+	private async Task<HttpResponseMessage> SendToOllamaAsync(HttpRequestMessage requestMessage, OllamaRequest? ollamaRequest, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+	{
+		requestMessage.ApplyCustomHeaders(this, ollamaRequest);
+
+		var response = await _client.SendAsync(requestMessage, completionOption, cancellationToken);
+
+		await EnsureSuccessStatusCode(response);
+
+		return response;
 	}
 
 	private async Task EnsureSuccessStatusCode(HttpResponseMessage response)

--- a/src/OllamaApiClientExtensions.cs
+++ b/src/OllamaApiClientExtensions.cs
@@ -66,6 +66,14 @@ public static class OllamaApiClientExtensions
 	}
 
 	/// <summary>
+	/// Sends a request to the /api/delete endpoint to delete a model
+	/// </summary>
+	/// <param name="model">The name of the model to delete</param>
+	/// <param name="cancellationToken">The token to cancel the operation with</param>
+	public static Task DeleteModel(this IOllamaApiClient client, string model, CancellationToken cancellationToken = default)
+	 => client.DeleteModel(new DeleteModelRequest { Model = model }, cancellationToken);
+
+	/// <summary>
 	/// Sends a request to the /api/pull endpoint to pull a new model
 	/// </summary>
 	/// <param name="client">The client used to execute the command</param>
@@ -124,4 +132,14 @@ public static class OllamaApiClientExtensions
 		};
 		return client.Generate(request, cancellationToken);
 	}
+
+	/// <summary>
+	/// Sends a request to the /api/show endpoint to show the information of a
+	/// model
+	/// </summary>
+	/// <param name="model">The name of the model the get the information for</param>
+	/// <param name="cancellationToken">The token to cancel the operation with</param>
+	/// <returns>The model information</returns>
+	public static Task<ShowModelResponse> ShowModel(this IOllamaApiClient client, string model, CancellationToken cancellationToken = default)
+	 => client.ShowModel(new ShowModelRequest { Model = model }, cancellationToken);
 }

--- a/test/OllamaApiClientTests.cs
+++ b/test/OllamaApiClientTests.cs
@@ -17,9 +17,10 @@ public class OllamaApiClientTests
 {
 	private OllamaApiClient _client;
 	private HttpResponseMessage? _response;
+	private Dictionary<string, string>? _expectedRequestHeaders;
 
 	[OneTimeSetUp]
-	public void Setup()
+	public void OneTimeSetUp()
 	{
 		var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
 
@@ -27,12 +28,42 @@ public class OllamaApiClientTests
 			.Protected()
 			.Setup<Task<HttpResponseMessage?>>(
 				"SendAsync",
-				ItExpr.Is<HttpRequestMessage>(_ => true),
+				ItExpr.Is<HttpRequestMessage>(r => ValidateExpectedRequestHeaders(r)),
 				ItExpr.IsAny<CancellationToken>())
 			.ReturnsAsync(() => _response);
 
 		var httpClient = new HttpClient(mockHandler.Object) { BaseAddress = new Uri("http://empty") };
 		_client = new OllamaApiClient(httpClient);
+
+		_client.DefaultRequestHeaders["required_default_header"] = "ok";
+	}
+
+	[SetUp]
+	public void SetUp()
+	{
+		_expectedRequestHeaders = null;
+	}
+
+	/// <summary>
+	/// Validates if the http request message has the same headers as defined in _expectedRequestHeaders.
+	/// This method does nothing if _expectedRequestHeaders is null.
+	/// </summary>
+	private bool ValidateExpectedRequestHeaders(HttpRequestMessage request)
+	{
+		if (_expectedRequestHeaders is null)
+			return true;
+
+		foreach (var expectedHeader in _expectedRequestHeaders)
+		{
+			if (!request.Headers.Contains(expectedHeader.Key))
+				throw new InvalidOperationException($"Expected header '{expectedHeader.Key}' was not found.");
+
+			var actualHeaderValue = request.Headers.GetValues(expectedHeader.Key).Single();
+			if (!string.Equals(actualHeaderValue, expectedHeader.Value))
+				throw new InvalidOperationException($"Request header '{expectedHeader.Key}' has value '{actualHeaderValue}' while '{expectedHeader.Value}' was expected.");
+		}
+
+		return true;
 	}
 
 	public class CreateModelMethod : OllamaApiClientTests
@@ -56,14 +87,63 @@ public class OllamaApiClientTests
 			stream.Seek(0, SeekOrigin.Begin);
 
 			var builder = new StringBuilder();
-			var modelStream = _client.CreateModel(
-				new CreateModelRequest(),
-				CancellationToken.None);
+			var modelStream = _client.CreateModel(new CreateModelRequest(), CancellationToken.None);
 
 			await foreach (var status in modelStream)
 				builder.Append(status?.Status);
 
 			builder.ToString().Should().Be("Creating modelDownloading modelModel created");
+		}
+
+		/// <summary>
+		/// Applies to all methods on the OllamaApiClient
+		/// </summary>
+		[Test, NonParallelizable]
+		public async Task Sends_Default_Request_Headers()
+		{
+			_expectedRequestHeaders = new Dictionary<string, string>
+			{
+				["required_default_header"] = "ok" // set as default on the OllamaApiClient (see above)
+			};
+
+			_response = new HttpResponseMessage
+			{
+				StatusCode = HttpStatusCode.OK,
+				Content = new StreamContent(new MemoryStream())
+			};
+
+			var builder = new StringBuilder();
+			await foreach (var status in _client.CreateModel(new CreateModelRequest(), CancellationToken.None))
+				builder.Append(status?.Status);
+
+			builder.Length.Should().Be(0); // assert anything, the test will fail if the expected headers are not available
+		}
+
+		/// <summary>
+		/// Applies to all methods on the OllamaApiClient
+		/// </summary>
+		[Test, NonParallelizable]
+		public async Task Sends_Custom_Request_Headers()
+		{
+			_expectedRequestHeaders = new Dictionary<string, string>
+			{
+				["api_method"] = "create" // set as custom request header (see below)
+			};
+
+			_response = new HttpResponseMessage
+			{
+				StatusCode = HttpStatusCode.OK,
+				Content = new StreamContent(new MemoryStream())
+			};
+
+			var request = new CreateModelRequest();
+			request.CustomHeaders["api_method"] = "create"; // set custom request headers
+
+			var builder = new StringBuilder();
+			await foreach (var status in _client.CreateModel(request, CancellationToken.None))
+				builder.Append(status?.Status);
+
+			builder.Length.Should().Be(0); // assert anything, the test will fail if the expected headers are not available
 		}
 	}
 

--- a/test/TestOllamaApiClient.cs
+++ b/test/TestOllamaApiClient.cs
@@ -24,7 +24,7 @@ public class TestOllamaApiClient : IOllamaApiClient
 		_expectedGenerateResponses = responses;
 	}
 
-	public async IAsyncEnumerable<ChatResponseStream?> Chat(ChatRequest chatRequest, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+	public async IAsyncEnumerable<ChatResponseStream?> Chat(ChatRequest request, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 	{
 		foreach (var response in _expectedChatResponses)
 		{
@@ -43,7 +43,7 @@ public class TestOllamaApiClient : IOllamaApiClient
 		throw new NotImplementedException();
 	}
 
-	public Task DeleteModel(string model, CancellationToken cancellationToken = default)
+	public Task DeleteModel(DeleteModelRequest request, CancellationToken cancellationToken = default)
 	{
 		throw new NotImplementedException();
 	}
@@ -87,12 +87,12 @@ public class TestOllamaApiClient : IOllamaApiClient
 		throw new NotImplementedException();
 	}
 
-	public IAsyncEnumerable<PushModelResponse?> PushModel(PushModelRequest modelRequest, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+	public IAsyncEnumerable<PushModelResponse?> PushModel(PushModelRequest request, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 	{
 		throw new NotImplementedException();
 	}
 
-	public Task<ShowModelResponse> ShowModel(string model, CancellationToken cancellationToken = default)
+	public Task<ShowModelResponse> ShowModel(ShowModelRequest request, CancellationToken cancellationToken = default)
 	{
 		throw new NotImplementedException();
 	}


### PR DESCRIPTION
Adds the possibilities to ... 
- ... add custom http request headers to requests
- ... define default http request headers to the `OllamaApiClient` that will be sent with every request
