### PR TITLE
Only build new versions on source code changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,10 @@ name: .NET Build, Test, and Publish Nuget Package
 on:
   push:
     branches: [ "main", "master" ]
+    paths: [ 'src/**' ]
   pull_request:
     branches: [ "main", "master" ]
+    paths: [ 'src/**' ]
 
 jobs:
 


### PR DESCRIPTION
The current action trigger builds new versions for changes on any file. This is not necessary, we need to filter on changes within the `/src` folder.