### PR TITLE
Removing extra info from request when not needed

### DIFF
--- a/src/Models/Chat/ChatRequest.cs
+++ b/src/Models/Chat/ChatRequest.cs
@@ -59,6 +59,7 @@ public class ChatRequest : OllamaRequest
 	/// Gets or sets the tools for the model to use if supported. Requires stream to be set to false.
 	/// </summary>
 	[JsonPropertyName("tools")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public IEnumerable<Tool>? Tools { get; set; }
 }
 

--- a/src/Models/Chat/Message.cs
+++ b/src/Models/Chat/Message.cs
@@ -69,12 +69,14 @@ public class Message
 	/// Gets or sets an array of base64-encoded images (for multimodal models such as llava).
 	/// </summary>
 	[JsonPropertyName("images")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public string[]? Images { get; set; }
 
 	/// <summary>
 	/// Gets or sets a list of tools the model wants to use (for models that support function calls, such as llama3.1).
 	/// </summary>
 	[JsonPropertyName("tool_calls")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public IEnumerable<ToolCall>? ToolCalls { get; set; }
 
 	/// <summary>

--- a/test/OllamaApiClientTests.cs
+++ b/test/OllamaApiClientTests.cs
@@ -17,6 +17,7 @@ public class OllamaApiClientTests
 {
 	private OllamaApiClient _client;
 	private HttpResponseMessage? _response;
+	private HttpRequestMessage? _request;
 	private Dictionary<string, string>? _expectedRequestHeaders;
 
 	[OneTimeSetUp]
@@ -50,6 +51,8 @@ public class OllamaApiClientTests
 	/// </summary>
 	private bool ValidateExpectedRequestHeaders(HttpRequestMessage request)
 	{
+		this._request = request;
+
 		if (_expectedRequestHeaders is null)
 			return true;
 
@@ -267,6 +270,12 @@ public class OllamaApiClientTests
 			result.PromptEvalDuration.Should().Be(35137000);
 			result.EvalCount.Should().Be(323);
 			result.EvalDuration.Should().Be(4575154000);
+
+			// Ensure that the request body does not contain the images, tools or tool_calls properties when not provided
+			var requestBody = await _request.Content.ReadAsStringAsync();
+			requestBody.Should().NotContain("tools");
+			requestBody.Should().NotContain("tool_calls");
+			requestBody.Should().NotContain("images");
 		}
 
 		[Test, NonParallelizable]


### PR DESCRIPTION
All requests sent to chat endpoint were sending `tools`, `tool_calls` and `images` when not being necessary in the server-side, this prevents extra information being sent to the server.