### PR TITLE
Support different types returned for arguments

### DIFF
--- a/src/Models/Chat/Converter/StringDictionaryConverter.cs
+++ b/src/Models/Chat/Converter/StringDictionaryConverter.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using System.Text.Json;
+
+namespace OllamaSharp.Models.Chat.Converter;
+
+/// <summary>
+/// Converts a <see cref="Dictionary{TKey,TValue}"/> with <see cref="string"/> keys and values to and from JSON.
+/// </summary>
+public class StringDictionaryConverter : JsonConverter<Dictionary<string, string>>
+{
+	/// <inheritdoc />
+	public override Dictionary<string, string> Read(ref Utf8JsonReader reader, Type typeToConvert,
+		JsonSerializerOptions options)
+	{
+		var dictionary = new Dictionary<string, string>();
+
+		if (reader.TokenType != JsonTokenType.StartObject)
+		{
+			throw new JsonException("Expected StartObject token");
+		}
+
+		while (reader.Read())
+		{
+			if (reader.TokenType == JsonTokenType.EndObject)
+			{
+				return dictionary;
+			}
+
+			// Read the property name
+			if (reader.TokenType != JsonTokenType.PropertyName)
+			{
+				throw new JsonException("Expected PropertyName token");
+			}
+
+			string propertyName = reader.GetString()!;
+
+			// Read the value
+			if (!reader.Read())
+			{
+				throw new JsonException("Unexpected end of JSON");
+			}
+
+			string value = reader.TokenType switch
+			{
+				JsonTokenType.Number => reader.GetDouble().ToString(),
+				JsonTokenType.True => "true",
+				JsonTokenType.False => "false",
+				JsonTokenType.Null => string.Empty,
+				_ => reader.GetString() ?? string.Empty // Fallback for other types
+			};
+
+			dictionary[propertyName] = value;
+		}
+
+		throw new JsonException("Expected EndObject token");
+	}
+
+	/// <inheritdoc />
+	public override void Write(Utf8JsonWriter writer, Dictionary<string, string> value,
+		JsonSerializerOptions options)
+	{
+		writer.WriteStartObject();
+
+		foreach (var kvp in value)
+		{
+			writer.WritePropertyName(kvp.Key);
+			writer.WriteStringValue(kvp.Value);
+		}
+
+		writer.WriteEndObject();
+	}
+}

--- a/src/Models/Chat/Message.cs
+++ b/src/Models/Chat/Message.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text.Json.Serialization;
+using OllamaSharp.Models.Chat.Converter;
 
 namespace OllamaSharp.Models.Chat;
 
@@ -106,6 +107,7 @@ public class Message
 		/// Gets or sets the arguments for the function, represented as a dictionary of argument names and values.
 		/// </summary>
 		[JsonPropertyName("arguments")]
+		[JsonConverter(typeof(StringDictionaryConverter))]
 		public Dictionary<string, string>? Arguments { get; set; }
 	}
 }

--- a/test/ChatTests.cs
+++ b/test/ChatTests.cs
@@ -47,10 +47,10 @@ public class ChatTests
 									Arguments = new Dictionary<string, string>()
 									{
 										["format"] = "celsius",
-										["location"] = "Los Angeles, CA"
+										["location"] = "Los Angeles, CA",
+										["number"] = "30",
 									}
 								}
-
 							}
 						]
 					}

--- a/test/OllamaApiClientTests.cs
+++ b/test/OllamaApiClientTests.cs
@@ -295,7 +295,8 @@ public class OllamaApiClientTests
 				                    "name": "get_current_weather",
 				                    "arguments": {
 				                        "format": "celsius",
-				                        "location": "Los Angeles, CA"
+				                        "location": "Los Angeles, CA",
+										"number": 42
 				                    }
 				                }
 				            }
@@ -353,6 +354,11 @@ public class OllamaApiClientTests
 										Description = "The format to return the weather in, e.g. 'celsius' or 'fahrenheit'",
 										Enum = ["celsius", "fahrenheit"]
 									},
+									["number"] = new()
+									{
+										Type = "integer",
+										Description = "The number of the day to get the weather for, e.g. 42"
+									}
 								},
 								Required = ["location", "format"],
 							}
@@ -378,6 +384,9 @@ public class OllamaApiClientTests
 
 			toolsFunction.Arguments!.ElementAt(1).Key.Should().Be("location");
 			toolsFunction.Arguments!.ElementAt(1).Value.Should().Be("Los Angeles, CA");
+
+			toolsFunction.Arguments!.ElementAt(2).Key.Should().Be("number");
+			toolsFunction.Arguments!.ElementAt(2).Value.Should().Be("42");
 		}
 	}
 


### PR DESCRIPTION
Temporaty fix (Non-breaking) to support parameters values that aren't strings from the Ollama API.

Ideally the Dictionary should support <string, object?> but this is coming soon as a breaking change, this PR changes it to not break for now, before the shift happens.