### PR TITLE
Fix disposable implementation

### DIFF
--- a/src/OllamaApiClient.cs
+++ b/src/OllamaApiClient.cs
@@ -377,7 +377,7 @@ public class OllamaApiClient : IOllamaApiClient, IChatClient, IEmbeddingGenerato
 	/// Releases the resources used by the <see cref="OllamaApiClient"/> instance.
 	/// Disposes the internal HTTP client if it was created internally.
 	/// </summary>
-	public void Dispose()
+	public void Cleanup()
 	{
 		if (_disposeHttpClient)
 			_client?.Dispose();
@@ -424,7 +424,7 @@ public class OllamaApiClient : IOllamaApiClient, IChatClient, IEmbeddingGenerato
 		=> key is null ? this as TService : null;
 
 	/// <inheritdoc/>
-	void IDisposable.Dispose() => Dispose();
+	public void Dispose() => Cleanup();
 
 	#endregion
 

--- a/src/OllamaApiClient.cs
+++ b/src/OllamaApiClient.cs
@@ -373,15 +373,6 @@ public class OllamaApiClient : IOllamaApiClient, IChatClient, IEmbeddingGenerato
 
 		response.EnsureSuccessStatusCode();
 	}
-	/// <summary>
-	/// Releases the resources used by the <see cref="OllamaApiClient"/> instance.
-	/// Disposes the internal HTTP client if it was created internally.
-	/// </summary>
-	public void Cleanup()
-	{
-		if (_disposeHttpClient)
-			_client?.Dispose();
-	}
 
 	#region IChatClient and IEmbeddingGenerator implementation
 
@@ -423,8 +414,15 @@ public class OllamaApiClient : IOllamaApiClient, IChatClient, IEmbeddingGenerato
 	TService? IEmbeddingGenerator<string, Embedding<float>>.GetService<TService>(object? key) where TService : class
 		=> key is null ? this as TService : null;
 
-	/// <inheritdoc/>
-	public void Dispose() => Cleanup();
+	/// <summary>
+	/// Releases the resources used by the <see cref="OllamaApiClient"/> instance.
+	/// Disposes the internal HTTP client if it was created internally.
+	/// </summary>
+	public void Dispose()
+	{
+		if (_disposeHttpClient)
+			_client?.Dispose();
+	}
 
 	#endregion
 

--- a/test/OllamaApiClientTests.cs
+++ b/test/OllamaApiClientTests.cs
@@ -49,7 +49,7 @@ public class OllamaApiClientTests
 	[OneTimeTearDown]
 	public void OneTimeTearDown()
 	{
-		_client.Cleanup();
+		_client.Dispose();
 	}
 
 	/// <summary>

--- a/test/OllamaApiClientTests.cs
+++ b/test/OllamaApiClientTests.cs
@@ -49,7 +49,7 @@ public class OllamaApiClientTests
 	[OneTimeTearDown]
 	public void OneTimeTearDown()
 	{
-		_client.Dispose();
+		_client.Cleanup();
 	}
 
 	/// <summary>


### PR DESCRIPTION
The IDisposable implementation for OllamaApiClient has some overloading issues.
More info here https://github.com/dotnet/roslyn-analyzers/issues/7462
Not sure if this is how you want to do it but here is one way to resolve it.

I personally see no reason to not just get rid of the Cleanup method and just put everything in dispose but I tried to leave it setup mostly the same.

As far as breaking changes go if someone is calling dispose it will still call the clean so it is really just an addition.