### PR TITLE
Add message tool support for AI Abstractions

### DIFF
--- a/demo/OllamaApiConsole.csproj
+++ b/demo/OllamaApiConsole.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+		<NoWarn>IDE0065</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/demo/OllamaApiConsole.csproj
+++ b/demo/OllamaApiConsole.csproj
@@ -5,8 +5,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-		<NoWarn>IDE0065</NoWarn>
-  </PropertyGroup>
+		<NoWarn>IDE0065;IDE0055;IDE0011</NoWarn>
+	</PropertyGroup>
 
   <ItemGroup>
 		<!-- 

--- a/src/MicrosoftAi/AbstractionMapper.cs
+++ b/src/MicrosoftAi/AbstractionMapper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.Extensions.AI;
 using OllamaSharp.Models;
@@ -44,13 +45,14 @@ public static class AbstractionMapper
 	/// <param name="chatMessages">A list of chat messages.</param>
 	/// <param name="options">Optional chat options to configure the request.</param>
 	/// <param name="stream">Indicates if the request should be streamed.</param>
-	public static ChatRequest ToOllamaSharpChatRequest(IList<ChatMessage> chatMessages, ChatOptions? options, bool stream)
+	/// <param name="serializerOptions">Serializer options</param>
+	public static ChatRequest ToOllamaSharpChatRequest(IList<ChatMessage> chatMessages, ChatOptions? options, bool stream, JsonSerializerOptions serializerOptions)
 	{
 		var request = new ChatRequest
 		{
 			Format = options?.ResponseFormat == ChatResponseFormat.Json ? "json" : null,
 			KeepAlive = null,
-			Messages = ToOllamaSharpMessages(chatMessages),
+			Messages = ToOllamaSharpMessages(chatMessages, serializerOptions),
 			Model = options?.ModelId ?? "", // will be set OllamaApiClient.SelectedModel if not set
 			Options = new Models.RequestOptions
 			{
@@ -189,17 +191,37 @@ public static class AbstractionMapper
 	/// Converts a list of Microsoft.Extensions.AI.<see cref="ChatMessage"/> to a list of Ollama <see cref="Message"/>.
 	/// </summary>
 	/// <param name="chatMessages">The chat messages to convert.</param>
-	private static IEnumerable<Message> ToOllamaSharpMessages(IList<ChatMessage> chatMessages)
+	private static IEnumerable<Message> ToOllamaSharpMessages(IList<ChatMessage> chatMessages, JsonSerializerOptions serializerOptions)
 	{
 		foreach (var cm in chatMessages)
 		{
+			var images = cm.Contents.OfType<DataContent>().Select(ToOllamaImage).Where(s => !string.IsNullOrEmpty(s)).ToArray();
+			var toolCalls = cm.Contents.OfType<FunctionCallContent>().Select(ToOllamaSharpToolCall).ToArray();
+
 			yield return new Message
 			{
 				Content = cm.Text,
-				Images = cm.Contents.OfType<DataContent>().Select(ToOllamaImage).Where(s => !string.IsNullOrEmpty(s)).ToArray(),
+				Images = images.Length > 0 ? images : null,
 				Role = ToOllamaSharpRole(cm.Role),
-				ToolCalls = cm.Contents.OfType<FunctionCallContent>().Select(ToOllamaSharpToolCall),
+				ToolCalls = toolCalls.Length > 0 ? toolCalls : null,
 			};
+
+			// If the message contains a function result, add it as a separate tool message
+			foreach (var frc in cm.Contents.OfType<FunctionResultContent>())
+			{
+				JsonElement jsonResult = JsonSerializer.SerializeToElement(frc.Result, serializerOptions);
+
+				yield return new Message
+				{
+					Content = JsonSerializer.Serialize(new OllamaFunctionResultContent
+					{
+						CallId = frc.CallId,
+						Result = jsonResult,
+					}, serializerOptions),
+					Role = Models.Chat.ChatRole.Tool,
+				};
+				continue;
+			}
 		}
 	}
 

--- a/src/MicrosoftAi/AbstractionMapper.cs
+++ b/src/MicrosoftAi/AbstractionMapper.cs
@@ -115,7 +115,7 @@ public static class AbstractionMapper
 	private static void TryAddOllamaOption<T>(ChatOptions microsoftChatOptions, OllamaOption option, Action<T> optionSetter)
 	{
 		if (microsoftChatOptions?.AdditionalProperties?.TryGetValue(option.Name, out var value) ?? false)
-			optionSetter((T)value);
+			optionSetter((T)value!);
 	}
 
 	/// <summary>
@@ -191,6 +191,7 @@ public static class AbstractionMapper
 	/// Converts a list of Microsoft.Extensions.AI.<see cref="ChatMessage"/> to a list of Ollama <see cref="Message"/>.
 	/// </summary>
 	/// <param name="chatMessages">The chat messages to convert.</param>
+	/// <param name="serializerOptions">Serializer options</param>
 	private static IEnumerable<Message> ToOllamaSharpMessages(IList<ChatMessage> chatMessages, JsonSerializerOptions serializerOptions)
 	{
 		foreach (var cm in chatMessages)

--- a/src/MicrosoftAi/OllamaFunctionResultContent.cs
+++ b/src/MicrosoftAi/OllamaFunctionResultContent.cs
@@ -1,0 +1,9 @@
+namespace OllamaSharp.MicrosoftAi;
+
+using System.Text.Json;
+
+internal sealed class OllamaFunctionResultContent
+{
+	public string? CallId { get; set; }
+	public JsonElement Result { get; set; }
+}

--- a/src/OllamaApiClient.cs
+++ b/src/OllamaApiClient.cs
@@ -394,7 +394,7 @@ public class OllamaApiClient : IOllamaApiClient, IChatClient, IEmbeddingGenerato
 	/// <inheritdoc/>
 	async Task<ChatCompletion> IChatClient.CompleteAsync(IList<ChatMessage> chatMessages, ChatOptions? options, CancellationToken cancellationToken)
 	{
-		var request = MicrosoftAi.AbstractionMapper.ToOllamaSharpChatRequest(chatMessages, options, stream: false);
+		var request = MicrosoftAi.AbstractionMapper.ToOllamaSharpChatRequest(chatMessages, options, stream: false, OutgoingJsonSerializerOptions);
 		var response = await ChatAsync(request, cancellationToken).StreamToEndAsync().ConfigureAwait(false);
 		return MicrosoftAi.AbstractionMapper.ToChatCompletion(response, response?.Model ?? request.Model ?? SelectedModel) ?? new ChatCompletion([]);
 	}
@@ -402,7 +402,7 @@ public class OllamaApiClient : IOllamaApiClient, IChatClient, IEmbeddingGenerato
 	/// <inheritdoc/>
 	async IAsyncEnumerable<StreamingChatCompletionUpdate> IChatClient.CompleteStreamingAsync(IList<ChatMessage> chatMessages, ChatOptions? options, [EnumeratorCancellation] CancellationToken cancellationToken)
 	{
-		var request = MicrosoftAi.AbstractionMapper.ToOllamaSharpChatRequest(chatMessages, options, stream: true);
+		var request = MicrosoftAi.AbstractionMapper.ToOllamaSharpChatRequest(chatMessages, options, stream: true, OutgoingJsonSerializerOptions);
 		await foreach (var response in ChatAsync(request, cancellationToken).ConfigureAwait(false))
 			yield return MicrosoftAi.AbstractionMapper.ToStreamingChatCompletionUpdate(response);
 	}

--- a/src/OllamaSharp.csproj
+++ b/src/OllamaSharp.csproj
@@ -19,6 +19,7 @@
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 		<SignAssembly>True</SignAssembly>
 		<AssemblyOriginatorKeyFile>..\OllamaSharp.snk</AssemblyOriginatorKeyFile>
+		<NoWarn>IDE0065</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/OllamaSharp.csproj
+++ b/src/OllamaSharp.csproj
@@ -19,7 +19,7 @@
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 		<SignAssembly>True</SignAssembly>
 		<AssemblyOriginatorKeyFile>..\OllamaSharp.snk</AssemblyOriginatorKeyFile>
-		<NoWarn>IDE0065</NoWarn>
+		<NoWarn>IDE0065;IDE0055;IDE0011</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/test/AbstractionMapperTests.cs
+++ b/test/AbstractionMapperTests.cs
@@ -1,7 +1,6 @@
 using System.Text.Json;
 using FluentAssertions;
 using Microsoft.Extensions.AI;
-using Moq;
 using NUnit.Framework;
 using OllamaSharp;
 using OllamaSharp.MicrosoftAi;
@@ -27,7 +26,7 @@ public partial class AbstractionMapperTests
 
 			var request = AbstractionMapper.ToOllamaSharpChatRequest(messages, options, stream: true, JsonSerializerOptions.Default);
 
-			request.Options.F16kv.Should().BeNull();
+			request.Options!.F16kv.Should().BeNull();
 			request.Options.FrequencyPenalty.Should().BeNull();
 			request.Options.LogitsAll.Should().BeNull();
 			request.Options.LowVram.Should().BeNull();
@@ -98,15 +97,15 @@ public partial class AbstractionMapperTests
 
 			chatRequest.Messages.Should().HaveCount(3);
 
-			var message = chatRequest.Messages.ElementAt(0);
+			var message = chatRequest.Messages!.ElementAt(0);
 			message.Content.Should().Be("Hi there.");
 			message.Role.Should().Be(OllamaSharp.Models.Chat.ChatRole.Assistant);
 
-			message = chatRequest.Messages.ElementAt(1);
+			message = chatRequest.Messages!.ElementAt(1);
 			message.Content.Should().Be("What is 3 + 4?");
 			message.Role.Should().Be(OllamaSharp.Models.Chat.ChatRole.User);
 
-			message = chatRequest.Messages.ElementAt(2);
+			message = chatRequest.Messages!.ElementAt(2);
 			message.Content.Should().Be("3 + 4 is 7");
 			message.Role.Should().Be(OllamaSharp.Models.Chat.ChatRole.Assistant);
 		}
@@ -147,11 +146,11 @@ public partial class AbstractionMapperTests
 
 			chatRequest.Messages.Should().HaveCount(2);
 
-			var message = chatRequest.Messages.ElementAt(0);
+			var message = chatRequest.Messages!.ElementAt(0);
 			message.Role.Should().Be(OllamaSharp.Models.Chat.ChatRole.User);
-			message.Images.Single().Should().Be(TRANSPARENT_PIXEL);
+			message.Images!.Single().Should().Be(TRANSPARENT_PIXEL);
 
-			message = chatRequest.Messages.ElementAt(1);
+			message = chatRequest.Messages!.ElementAt(1);
 			message.Role.Should().Be(OllamaSharp.Models.Chat.ChatRole.Assistant);
 			message.Images.Should().HaveCount(4);
 		}
@@ -178,11 +177,11 @@ public partial class AbstractionMapperTests
 
 			var chatRequest = AbstractionMapper.ToOllamaSharpChatRequest(chatMessages, options, stream: true, JsonSerializerOptions.Default);
 
-			var tool = chatRequest.Tools.Single();
-			tool.Function.Description.Should().Be("Gets the current weather for a current location");
+			var tool = chatRequest.Tools!.Single();
+			tool.Function!.Description.Should().Be("Gets the current weather for a current location");
 			tool.Function.Name.Should().Be("get_weather");
-			tool.Function.Parameters.Properties.Should().HaveCount(2);
-			tool.Function.Parameters.Properties["city"].Description.Should().Be("The city to get the weather for");
+			tool.Function.Parameters!.Properties.Should().HaveCount(2);
+			tool.Function.Parameters.Properties!["city"].Description.Should().Be("The city to get the weather for");
 			tool.Function.Parameters.Properties["city"].Enum.Should().BeEmpty();
 			tool.Function.Parameters.Properties["city"].Type.Should().Be("string");
 			tool.Function.Parameters.Properties["unit"].Description.Should().Be("The unit to calculate the current temperature to");
@@ -204,14 +203,14 @@ public partial class AbstractionMapperTests
 					AuthorName = "a1",
 					RawRepresentation = null,
 					Role = Microsoft.Extensions.AI.ChatRole.Tool,
-					Text = "The weather in Honululu is 25°C."
+					Text = "The weather in Honolulu is 25°C."
 				}
 			};
 
 			var chatRequest = AbstractionMapper.ToOllamaSharpChatRequest(chatMessages, new(), stream: true, JsonSerializerOptions.Default);
 
-			var tool = chatRequest.Messages.Single();
-			tool.Content.Should().Contain("The weather in Honululu is 25°C.");
+			var tool = chatRequest.Messages!.Single();
+			tool.Content.Should().Contain("The weather in Honolulu is 25°C.");
 			tool.Role.Should().Be(OllamaSharp.Models.Chat.ChatRole.Tool);
 		}
 
@@ -281,7 +280,7 @@ public partial class AbstractionMapperTests
 
 			chatRequest.Format.Should().Be("json");
 			chatRequest.Model.Should().Be("llama3.1:405b");
-			chatRequest.Options.FrequencyPenalty.Should().Be(0.5f);
+			chatRequest.Options!.FrequencyPenalty.Should().Be(0.5f);
 			chatRequest.Options.PresencePenalty.Should().Be(0.3f);
 			chatRequest.Options.Stop.Should().BeEquivalentTo("stop1", "stop2", "stop3");
 			chatRequest.Options.Temperature.Should().Be(0.1f);
@@ -357,7 +356,7 @@ public partial class AbstractionMapperTests
 
 			var ollamaRequest = AbstractionMapper.ToOllamaSharpChatRequest([], options, stream: true, JsonSerializerOptions.Default);
 
-			ollamaRequest.Options.F16kv.Should().Be(true);
+			ollamaRequest.Options!.F16kv.Should().Be(true);
 			ollamaRequest.Options.FrequencyPenalty.Should().Be(0.11f);
 			ollamaRequest.Options.LogitsAll.Should().Be(false);
 			ollamaRequest.Options.LowVram.Should().Be(true);
@@ -415,8 +414,8 @@ public partial class AbstractionMapperTests
 
 			var chatCompletion = AbstractionMapper.ToChatCompletion(stream, usedModel: null);
 
-			chatCompletion.AdditionalProperties.Should().NotBeNull();
-			chatCompletion.AdditionalProperties["eval_duration"].Should().Be(TimeSpan.FromSeconds(2.222222222));
+			chatCompletion!.AdditionalProperties.Should().NotBeNull();
+			chatCompletion.AdditionalProperties!["eval_duration"].Should().Be(TimeSpan.FromSeconds(2.222222222));
 			chatCompletion.AdditionalProperties["load_duration"].Should().Be(TimeSpan.FromSeconds(3.333333333));
 			chatCompletion.AdditionalProperties["total_duration"].Should().Be(TimeSpan.FromSeconds(6.666666666));
 			chatCompletion.AdditionalProperties["prompt_eval_duration"].Should().Be(TimeSpan.FromSeconds(5.555555555));
@@ -433,7 +432,7 @@ public partial class AbstractionMapperTests
 			chatCompletion.ModelId.Should().Be("llama3.1:8b");
 			chatCompletion.RawRepresentation.Should().Be(stream);
 			chatCompletion.Usage.Should().NotBeNull();
-			chatCompletion.Usage.InputTokenCount.Should().Be(411);
+			chatCompletion.Usage!.InputTokenCount.Should().Be(411);
 			chatCompletion.Usage.OutputTokenCount.Should().Be(111);
 			chatCompletion.Usage.TotalTokenCount.Should().Be(111 + 411);
 		}
@@ -502,9 +501,9 @@ public partial class AbstractionMapperTests
 			chatMessage.Contents.Should().HaveCount(2);
 			chatMessage.Contents.First().Should().BeOfType<TextContent>().Which.Text.Should().Be("It seems the sun will be out all day.");
 			var toolCall = chatMessage.Contents.Last() as FunctionCallContent;
-			toolCall.AdditionalProperties.Should().BeNull();
+			toolCall!.AdditionalProperties.Should().BeNull();
 			toolCall.Arguments.Should().HaveCount(2);
-			toolCall.Arguments["city"].Should().Be("Honululu");
+			toolCall.Arguments!["city"].Should().Be("Honululu");
 			toolCall.Arguments["unit"].Should().Be("celsius");
 			toolCall.CallId.Should().NotBeEmpty().And.HaveLength(8); // random guid
 			toolCall.Exception.Should().BeNull();
@@ -579,7 +578,7 @@ public partial class AbstractionMapperTests
 			mappedResponse[0].Vector.ToArray().Should().BeEquivalentTo([0.101f, 0.102f, 0.103f]);
 			mappedResponse[1].ModelId.Should().Be("model");
 			mappedResponse[1].Vector.ToArray().Should().BeEquivalentTo([0.201f, 0.202f, 0.203f]);
-			mappedResponse.Usage.InputTokenCount.Should().Be(18);
+			mappedResponse.Usage!.InputTokenCount.Should().Be(18);
 			mappedResponse.Usage.OutputTokenCount.Should().BeNull();
 			mappedResponse.Usage.TotalTokenCount.Should().Be(18);
 		}

--- a/test/AbstractionMapperTests.cs
+++ b/test/AbstractionMapperTests.cs
@@ -181,7 +181,7 @@ public partial class AbstractionMapperTests
 				}
 			};
 
-			var request = AbstractionMapper.ToOllamaSharpChatRequest(chatMessages, null, stream: true);
+			var request = AbstractionMapper.ToOllamaSharpChatRequest(chatMessages, null, stream: true, JsonSerializerOptions.Default);
 			request.Messages.Single().Images.Single().Should().Be("QUJD");
 		}
 
@@ -208,7 +208,7 @@ public partial class AbstractionMapperTests
 
 			Action act = () =>
 			{
-				var request = AbstractionMapper.ToOllamaSharpChatRequest(chatMessages, null, stream: true);
+				var request = AbstractionMapper.ToOllamaSharpChatRequest(chatMessages, null, stream: true, JsonSerializerOptions.Default);
 				request.Messages.Should().NotBeEmpty(); // access .Messages to invoke the evaluation of IEnumerable<Message>
 			};
 

--- a/test/ChatTests.cs
+++ b/test/ChatTests.cs
@@ -117,7 +117,6 @@ public class ChatTests
 			history[1].Content.Should().Be("Hi tool.");
 		}
 
-
 		[Test]
 		public async Task Sends_Image_Bytes_As_Base64()
 		{

--- a/test/OllamaApiClientTests.cs
+++ b/test/OllamaApiClientTests.cs
@@ -282,7 +282,7 @@ public class OllamaApiClientTests
 			_request.Should().NotBeNull();
 			_requestContent.Should().NotBeNull();
 
-      _requestContent.Should().Contain("Why?");
+			_requestContent.Should().Contain("Why?");
 			_requestContent.Should().Contain("Because!");
 			_requestContent.Should().Contain("And where?");
 			_requestContent.Should().Contain("\"top_p\":100");

--- a/test/Tests.csproj
+++ b/test/Tests.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-		<NoWarn>IDE0065</NoWarn>
-  </PropertyGroup>
+		<NoWarn>IDE0065;IDE0055;IDE0011</NoWarn>
+	</PropertyGroup>
 
   <ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="6.12.1" />

--- a/test/Tests.csproj
+++ b/test/Tests.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+		<NoWarn>IDE0065</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Currently the implementation is ignoring sending functions results back to the model with the `Message.Tool` Role, this implementation adds this behavior for `AI Abstractions Mapping`
- Warnings fixes
- Not sending tool_calls or images when not provided.