### PR TITLE
Publicly expose OllamaApiClient.Dispose

### DIFF
--- a/src/OllamaApiClient.cs
+++ b/src/OllamaApiClient.cs
@@ -426,7 +426,7 @@ public class OllamaApiClient : IOllamaApiClient, IChatClient, IEmbeddingGenerato
 	/// Releases the resources used by the <see cref="OllamaApiClient"/> instance.
 	/// Disposes the internal HTTP client if it was created internally.
 	/// </summary>
-	void IDisposable.Dispose()
+	public void Dispose()
 	{
 		if (_disposeHttpClient)
 			_client?.Dispose();


### PR DESCRIPTION
This means that when putting the client in a field/property, you don't have to write code like:
```cs
((IDisposable)Client)?.Dispose();
```
Instead you can just write:
```cs
Client?.Dispose();
```