### PR TITLE
Upgrade target frameworks and packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,8 @@ jobs:
       uses: actions/setup-dotnet@v2
       with:
         dotnet-version: | 
-          6.0.x
           8.0.x
+          9.0.x
 
     - name: Restore dependencies
       run: dotnet restore OllamaSharp.sln

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,7 @@
+<Project>
+    <PropertyGroup>
+        <LangVersion>preview</LangVersion>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+    </PropertyGroup>
+</Project>

--- a/OllamaSharp.sln
+++ b/OllamaSharp.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.5.002.0
+VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OllamaSharp", "src\OllamaSharp.csproj", "{0194817F-1B9C-4D44-8960-1A0DC92D9D22}"
 EndProject

--- a/demo/OllamaApiConsole.csproj
+++ b/demo/OllamaApiConsole.csproj
@@ -2,7 +2,8 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
+                <LangVersion>latest</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<NoWarn>IDE0065;IDE0055;IDE0011</NoWarn>

--- a/demo/OllamaApiConsole.csproj
+++ b/demo/OllamaApiConsole.csproj
@@ -3,10 +3,6 @@
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net9.0</TargetFramework>
-                <LangVersion>latest</LangVersion>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-		<NoWarn>IDE0065;IDE0055;IDE0011</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/demo/OllamaApiConsole.csproj
+++ b/demo/OllamaApiConsole.csproj
@@ -10,11 +10,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<!-- 
-		SixLabors.ImageSharp added explicitly to fix CVE-2024-41131: https://github.com/advisories/GHSA-63p8-c4ww-9cg7  
-		and can be removed once Spectre.Console.ImageSharp uses a version greater than 3.1.4
-		-->
-		<PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
 		<PackageReference Include="Spectre.Console" Version="0.49.1" />
 		<PackageReference Include="Spectre.Console.ImageSharp" Version="0.49.1" />
 	</ItemGroup>

--- a/src/MicrosoftAi/AbstractionMapper.cs
+++ b/src/MicrosoftAi/AbstractionMapper.cs
@@ -310,7 +310,7 @@ internal static class AbstractionMapper
 			"system" => Microsoft.Extensions.AI.ChatRole.System,
 			"user" => Microsoft.Extensions.AI.ChatRole.User,
 			"tool" => Microsoft.Extensions.AI.ChatRole.Tool,
-			_ => new Microsoft.Extensions.AI.ChatRole(role.ToString()),
+			_ => new Microsoft.Extensions.AI.ChatRole(role.ToString()!),
 		};
 	}
 

--- a/src/Models/JsonSchema.cs
+++ b/src/Models/JsonSchema.cs
@@ -44,25 +44,25 @@ public class JsonSchema
 					? new Item
 					{
 						Type = IsPrimitiveType(prop.PropertyType.IsArray
-							? prop.PropertyType.GetElementType()
+							? prop.PropertyType.GetElementType()!
 							: prop.PropertyType.GetGenericArguments().First())
 							? GetTypeName(prop.PropertyType.IsArray
-								? prop.PropertyType.GetElementType()
+								? prop.PropertyType.GetElementType()!
 								: prop.PropertyType.GetGenericArguments().First())
 							: "object",
 						Properties = IsPrimitiveType(prop.PropertyType.IsArray
-							? prop.PropertyType.GetElementType()
+							? prop.PropertyType.GetElementType()!
 							: prop.PropertyType.GetGenericArguments().First())
 							? null
 							: ToJsonSchema(prop.PropertyType.IsArray
-								? prop.PropertyType.GetElementType()
+								? prop.PropertyType.GetElementType()!
 								: prop.PropertyType.GetGenericArguments().First()).Properties,
 						Required = IsPrimitiveType(prop.PropertyType.IsArray
-							? prop.PropertyType.GetElementType()
+							? prop.PropertyType.GetElementType()!
 							: prop.PropertyType.GetGenericArguments().First())
 							? null
 							: (prop.PropertyType.IsArray
-								? prop.PropertyType.GetElementType()
+								? prop.PropertyType.GetElementType()!
 								: prop.PropertyType.GetGenericArguments().First()).GetProperties()
 							.Where(info =>
 								!info.PropertyType.IsGenericType ||

--- a/src/OllamaSharp.csproj
+++ b/src/OllamaSharp.csproj
@@ -2,8 +2,6 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net9.0</TargetFrameworks>
-		<LangVersion>latest</LangVersion>
-		<Nullable>enable</Nullable>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<Title>OllamaSharp</Title>

--- a/src/OllamaSharp.csproj
+++ b/src/OllamaSharp.csproj
@@ -44,7 +44,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0" />
 		<PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.0.1-preview.1.24570.5" />
 	</ItemGroup>
 </Project>

--- a/src/OllamaSharp.csproj
+++ b/src/OllamaSharp.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net9.0</TargetFrameworks>
+		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
-		<LangVersion>12</LangVersion>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<Title>OllamaSharp</Title>

--- a/test/FunctionalTests/ChatTests.cs
+++ b/test/FunctionalTests/ChatTests.cs
@@ -1,5 +1,4 @@
 using FluentAssertions;
-using Microsoft.Extensions.AI;
 using NUnit.Framework;
 using OllamaSharp;
 

--- a/test/FunctionalTests/OllamaApiClientTests.cs
+++ b/test/FunctionalTests/OllamaApiClientTests.cs
@@ -1,5 +1,4 @@
 using FluentAssertions;
-using Microsoft.Extensions.AI;
 using NUnit.Framework;
 using OllamaSharp;
 using OllamaSharp.Models;
@@ -15,9 +14,7 @@ public class OllamaApiClientTests
 	private readonly string _localModel = "OllamaSharpTest";
 	private readonly string _embeddingModel = "all-minilm:22m";
 
-#pragma warning disable NUnit1032
 	private OllamaApiClient _client = null!;
-#pragma warning restore NUnit1032
 
 	[SetUp]
 	public async Task Setup()

--- a/test/TestOllamaApiClient.cs
+++ b/test/TestOllamaApiClient.cs
@@ -1,11 +1,11 @@
+#pragma warning disable CS8424 // The EnumeratorCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable
+
 using System.Runtime.CompilerServices;
 using OllamaSharp;
 using OllamaSharp.Models;
 using OllamaSharp.Models.Chat;
 
 namespace Tests;
-
-#pragma warning disable CS8424 // The EnumeratorCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable
 
 public class TestOllamaApiClient : IOllamaApiClient
 {
@@ -98,6 +98,4 @@ public class TestOllamaApiClient : IOllamaApiClient
 	{
 		throw new NotImplementedException();
 	}
-
-#pragma warning restore CS8424 // The EnumeratorCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable
 }

--- a/test/Tests.csproj
+++ b/test/Tests.csproj
@@ -2,12 +2,9 @@
 
 	<PropertyGroup>
 		<TargetFramework>net9.0</TargetFramework>
-                <LangVersion>latest</LangVersion>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
+		<NoWarn>CS8604;CS8602</NoWarn>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<NoWarn>IDE0065;IDE0055;IDE0011;CS8602;CS8604;S6608</NoWarn>
 		<SignAssembly>True</SignAssembly>
 		<AssemblyOriginatorKeyFile>..\OllamaSharp.snk</AssemblyOriginatorKeyFile>
 	</PropertyGroup>

--- a/test/Tests.csproj
+++ b/test/Tests.csproj
@@ -13,16 +13,16 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FluentAssertions" Version="6.12.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+		<PackageReference Include="FluentAssertions" Version="7.0.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="NUnit" Version="4.2.2" />
+		<PackageReference Include="NUnit" Version="4.3.2" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-		<PackageReference Include="NUnit.Analyzers" Version="4.3.0">
+		<PackageReference Include="NUnit.Analyzers" Version="4.5.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="6.0.2">
+		<PackageReference Include="coverlet.collector" Version="6.0.3">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/test/Tests.csproj
+++ b/test/Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
+                <LangVersion>latest</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>


### PR DESCRIPTION
This pull request:
- Adds `netstandard2.1`, `.net8.0`, `net9.0` targets, which may improve performance at a small cost to the size of the `nupkg`.
- Upgrades NuGet packages to the latest versions.

I also noticed this library is using NUnit, which is a little old and verbose. Would you be interested in migrating to [xUnit](https://github.com/xunit/xunit) (or [TUnit](https://github.com/thomhurst/TUnit)), or are you okay sticking with NUnit?