### PR TITLE
Corrected documentation build after #162 added .NET 9

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,9 @@ jobs:
       - name: Dotnet Setup
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 8.x
+          dotnet-version: |
+            8.x
+            9.x
 
       - run: dotnet tool update -g docfx
       - run: docfx ./docfx.json


### PR DESCRIPTION
When #162 was merged, it added .NET 9 to the library, but the documentation workflow was not updated to also utilize .NET 9. This has caused all documentation builds to fail since.

This change adds appropriate .NET version to the workflow file.