### PR TITLE
Moved the rest of the model JsonPropertyNames to constants for consistency

### DIFF
--- a/src/Chat.cs
+++ b/src/Chat.cs
@@ -248,7 +248,7 @@ public class Chat
 	/// An <see cref="IAsyncEnumerable{T}"/> of strings representing the streamed response from the server.
 	/// </returns>
 	/// <example>
-	/// Example usage of the <see cref="SendAsAsync"/> method:
+	/// Example usage of the <see cref="SendAsAsync(string, string)"/> method:
 	/// <code>
 	/// var client = new OllamaApiClient("http://localhost:11434", "llama3.2-vision:latest");
 	/// var chat = new Chat(client);

--- a/src/Constants/Application.cs
+++ b/src/Constants/Application.cs
@@ -55,7 +55,6 @@ internal static class Application
 	public const string ParentModel = "parent_model";
 	public const string Family = "family";
 	public const string Families = "families";
-	public const string ParameterCount = "parameter_count";
 	public const string QuantizationLevel = "quantization_level";
 	public const string SizeVram = "size_vram";
 	public const string ExpiresAt = "expires_at";
@@ -101,4 +100,5 @@ internal static class Application
 	public const string Total = "total";
 	public const string Completed = "completed";
 	public const string Embeddings = "embeddings";
+	public const string ParameterSize = "parameter_size";
 }

--- a/src/Constants/Application.cs
+++ b/src/Constants/Application.cs
@@ -6,6 +6,7 @@ namespace OllamaSharp.Constants;
 internal static class Application
 {
 	public const string Ollama = "ollama";
+
 	public const string KeepAlive = "keep_alive";
 	public const string Truncate = "truncate";
 	public const string LoadDuration = "load_duration";
@@ -16,22 +17,88 @@ internal static class Application
 	public const string EvalCount = "eval_count";
 	public const string Context = "context";
 	public const string Done = "done";
+	public const string DoneReason = "done_reason";
 	public const string Response = "response";
 	public const string CreatedAt = "created_at";
 	public const string Model = "model";
-	
+	public const string Models = "models";
+	public const string Name = "name";
+	public const string Size = "size";
+	public const string Format = "format";
+	public const string Images = "images";
+	public const string Template = "template";
+	public const string ModifiedAt = "modified_at";
+	public const string ModelFile = "modelfile";
+	public const string Path = "path";
+	public const string Stream = "stream";
+	public const string Quantize = "quantize";
+	public const string Status = "status";
+	public const string Input = "input";
+	public const string Prompt = "prompt";
+	public const string Suffix = "suffix";
+	public const string Options = "options";
+	public const string Source = "source";
+	public const string Destination = "destination";
 	public const string Assistant = "assistant";
 	public const string System = "system";
 	public const string User = "user";
 	public const string Tool = "tool";
-	
 	public const string Length = "length";
 	public const string Stop = "stop";
-	
 	public const string Object = "object";
 	public const string Function = "function";
-
 	public const string Json = "json";
-	
 	public const string NotApplicable = "n/a";
+	public const string Raw = "raw";
+	public const string Digest = "digest";
+	public const string Details = "details";
+	public const string ParentModel = "parent_model";
+	public const string Family = "family";
+	public const string Families = "families";
+	public const string ParameterCount = "parameter_count";
+	public const string QuantizationLevel = "quantization_level";
+	public const string SizeVram = "size_vram";
+	public const string ExpiresAt = "expires_at";
+	public const string MiroStat = "mirostat";
+	public const string MiroStatEta = "mirostat_eta";
+	public const string MiroStatTau = "mirostat_tau";
+	public const string NumCtx = "num_ctx";
+	public const string NumGqa = "num_gqa";
+	public const string NumGpu = "num_gpu";
+	public const string MainGpu = "main_gpu";
+	public const string NumBatch = "num_batch";
+	public const string NumThread = "num_thread";
+	public const string NumKeep = "num_keep";
+	public const string RepeatLastN = "repeat_last_n";
+	public const string RepeatPenalty = "repeat_penalty";
+	public const string PresencePenalty = "presence_penalty";
+	public const string FrequencyPenalty = "frequency_penalty";
+	public const string Temperature = "temperature";
+	public const string Seed = "seed";
+	public const string TfsZ = "tfs_z";
+	public const string NumPredict = "num_predict";
+	public const string TopK = "top_k";
+	public const string TopP = "top_p";
+	public const string MinP = "min_p";
+	public const string TypicalP = "typical_p";
+	public const string PenalizeNewline = "penalize_newline";
+	public const string UseMmap = "use_mmap";
+	public const string UseMlock = "use_mlock";
+	public const string LowVram = "low_vram";
+	public const string F16kv = "f16_kv";
+	public const string LogitsAll = "logits_all";
+	public const string VocabOnly = "vocab_only";
+	public const string Numa = "numa";
+	public const string License = "license";
+	public const string Parameters = "parameters";
+	public const string ModelInfo = "model_info";
+	public const string Projector = "projector_info";
+	public const string GeneralArchitecture = "general.architecture";
+	public const string GeneralFileType = "general.file_type";
+	public const string GeneralParameterCount = "general.parameter_count";
+	public const string GeneralQuantizationVersion = "general.quantization_version";
+	public const string Insecure = "insecure";
+	public const string Total = "total";
+	public const string Completed = "completed";
+	public const string Embeddings = "embeddings";
 }

--- a/src/MicrosoftAi/AbstractionMapper.cs
+++ b/src/MicrosoftAi/AbstractionMapper.cs
@@ -55,7 +55,7 @@ internal static class AbstractionMapper
 			Format = Equals(options?.ResponseFormat, ChatResponseFormat.Json) ? Application.Json : null,
 			KeepAlive = null,
 			Messages = ToOllamaSharpMessages(chatMessages, serializerOptions),
-			Model = options?.ModelId ?? "", // will be set OllamaApiClient.SelectedModel if not set
+			Model = options?.ModelId ?? string.Empty, // will be set OllamaApiClient.SelectedModel if not set
 			Options = new RequestOptions
 			{
 				FrequencyPenalty = options?.FrequencyPenalty,
@@ -95,8 +95,7 @@ internal static class AbstractionMapper
 			TryAddOllamaOption<int?>(options, OllamaOption.RepeatLastN, v => request.Options.RepeatLastN = (int?)v);
 			TryAddOllamaOption<float?>(options, OllamaOption.RepeatPenalty, v => request.Options.RepeatPenalty = (float?)v);
 			TryAddOllamaOption<int?>(options, OllamaOption.Seed, v => request.Options.Seed = (int?)v);
-			TryAddOllamaOption<string[]?>(options, OllamaOption.Stop,
-				v => request.Options.Stop = (v as IEnumerable<string>)?.ToArray());
+			TryAddOllamaOption<string[]?>(options, OllamaOption.Stop, v => request.Options.Stop = (v as IEnumerable<string>)?.ToArray());
 			TryAddOllamaOption<float?>(options, OllamaOption.Temperature, v => request.Options.Temperature = (float?)v);
 			TryAddOllamaOption<float?>(options, OllamaOption.TfsZ, v => request.Options.TfsZ = (float?)v);
 			TryAddOllamaOption<int?>(options, OllamaOption.TopK, v => request.Options.TopK = (int?)v);

--- a/src/Models/Chat/ChatDoneResponseStream.cs
+++ b/src/Models/Chat/ChatDoneResponseStream.cs
@@ -23,7 +23,7 @@ public class ChatDoneResponseStream : ChatResponseStream
 	/// <summary>
 	/// The number of tokens in the prompt
 	/// </summary>
-	[JsonPropertyName("prompt_eval_count")]
+	[JsonPropertyName(Application.PromptEvalCount)]
 	public int PromptEvalCount { get; set; }
 
 	/// <summary>
@@ -35,7 +35,7 @@ public class ChatDoneResponseStream : ChatResponseStream
 	/// <summary>
 	/// The number of tokens in the response
 	/// </summary>
-	[JsonPropertyName("eval_count")]
+	[JsonPropertyName(Application.EvalCount)]
 	public int EvalCount { get; set; }
 
 	/// <summary>
@@ -47,6 +47,6 @@ public class ChatDoneResponseStream : ChatResponseStream
 	/// <summary>
 	/// The reason for the completion of the chat
 	/// </summary>
-	[JsonPropertyName("done_reason")]
+	[JsonPropertyName(Application.DoneReason)]
 	public string? DoneReason { get; set; }
 }

--- a/src/Models/CopyModel.cs
+++ b/src/Models/CopyModel.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using OllamaSharp.Constants;
 
 namespace OllamaSharp.Models;
 
@@ -11,12 +12,12 @@ public class CopyModelRequest : OllamaRequest
 	/// <summary>
 	/// The source model name
 	/// </summary>
-	[JsonPropertyName("source")]
+	[JsonPropertyName(Application.Source)]
 	public string Source { get; set; } = null!;
 
 	/// <summary>
 	/// The destination model name
 	/// </summary>
-	[JsonPropertyName("destination")]
+	[JsonPropertyName(Application.Destination)]
 	public string Destination { get; set; } = null!;
 }

--- a/src/Models/CreateModel.cs
+++ b/src/Models/CreateModel.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using OllamaSharp.Constants;
 
 namespace OllamaSharp.Models;
 
@@ -18,32 +19,32 @@ public class CreateModelRequest : OllamaRequest
 	/// <summary>
 	/// Name of the model to create
 	/// </summary>
-	[JsonPropertyName("model")]
+	[JsonPropertyName(Application.Model)]
 	public string? Model { get; set; }
 
 	/// <summary>
 	/// Contents of the Modelfile
 	/// See https://github.com/jmorganca/ollama/blob/main/docs/modelfile.md
 	/// </summary>
-	[JsonPropertyName("modelfile")]
+	[JsonPropertyName(Application.ModelFile)]
 	public string ModelFileContent { get; set; } = null!;
 
 	/// <summary>
 	/// Path to the Modelfile (optional)
 	/// </summary>
-	[JsonPropertyName("path")]
+	[JsonPropertyName(Application.Path)]
 	public string? Path { get; set; }
 
 	/// <summary>
 	/// If false the response will be returned as a single response object, rather than a stream of objects (optional)
 	/// </summary>
-	[JsonPropertyName("stream")]
+	[JsonPropertyName(Application.Stream)]
 	public bool Stream { get; set; }
 
 	/// <summary>
 	/// Set the quantization level for quantize model when importing (e.g. q4_0, optional)
 	/// </summary>
-	[JsonPropertyName("quantize")]
+	[JsonPropertyName(Application.Quantize)]
 	public string? Quantize { get; set; }
 }
 
@@ -55,6 +56,6 @@ public class CreateModelResponse
 	/// <summary>
 	/// Represents the status of a model creation.
 	/// </summary>
-	[JsonPropertyName("status")]
+	[JsonPropertyName(Application.Status)]
 	public string Status { get; set; } = null!;
 }

--- a/src/Models/DeleteModel.cs
+++ b/src/Models/DeleteModel.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using OllamaSharp.Constants;
 
 namespace OllamaSharp.Models;
 
@@ -13,6 +14,6 @@ public class DeleteModelRequest : OllamaRequest
 	/// <summary>
 	/// The name of the model to delete
 	/// </summary>
-	[JsonPropertyName("model")]
+	[JsonPropertyName(Application.Model)]
 	public string? Model { get; set; }
 }

--- a/src/Models/Embed.cs
+++ b/src/Models/Embed.cs
@@ -13,27 +13,27 @@ public class EmbedRequest : OllamaRequest
 	/// <summary>
 	/// The name of the model to generate embeddings from
 	/// </summary>
-	[JsonPropertyName("model")]
+	[JsonPropertyName(Application.Model)]
 	public string Model { get; set; } = null!;
 
 	/// <summary>
 	/// The text to generate embeddings for
 	/// </summary>
-	[JsonPropertyName("input")]
+	[JsonPropertyName(Application.Input)]
 	public List<string> Input { get; set; } = null!;
 
 	/// <summary>
 	/// Additional model parameters listed in the documentation for the Modelfile
 	/// such as temperature.
 	/// </summary>
-	[JsonPropertyName("options")]
+	[JsonPropertyName(Application.Options)]
 	public RequestOptions? Options { get; set; }
 
 	/// <summary>
 	/// Gets or sets the KeepAlive property, which decides how long a given
 	/// model should stay loaded.
 	/// </summary>
-	[JsonPropertyName("keep_alive")]
+	[JsonPropertyName(Application.KeepAlive)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public long? KeepAlive { get; set; }
 
@@ -41,7 +41,7 @@ public class EmbedRequest : OllamaRequest
 	/// Truncates the end of each input to fit within context length.
 	/// Returns error if false and context length is exceeded. Defaults to true
 	/// </summary>
-	[JsonPropertyName("truncate")]
+	[JsonPropertyName(Application.Truncate)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public bool? Truncate { get; set; }
 }
@@ -54,7 +54,7 @@ public class EmbedResponse
 	/// <summary>
 	/// An array of embeddings for the input text
 	/// </summary>
-	[JsonPropertyName("embeddings")]
+	[JsonPropertyName(Application.Embeddings)]
 	public List<float[]> Embeddings { get; set; } = null!;
 
 	/// <summary>
@@ -72,6 +72,6 @@ public class EmbedResponse
 	/// <summary>
 	/// The number of tokens in the input text
 	/// </summary>
-	[JsonPropertyName("prompt_eval_count")]
+	[JsonPropertyName(Application.PromptEvalCount)]
 	public int? PromptEvalCount { get; set; }
 }

--- a/src/Models/Generate.cs
+++ b/src/Models/Generate.cs
@@ -1,5 +1,4 @@
-using System;
-using System.Net.Mime;
+using System.Globalization;
 using System.Text.Json.Serialization;
 using OllamaSharp.Constants;
 
@@ -17,19 +16,19 @@ public class GenerateRequest : OllamaRequest
 	/// <summary>
 	/// The model name (required)
 	/// </summary>
-	[JsonPropertyName("model")]
+	[JsonPropertyName(Application.Model)]
 	public string Model { get; set; } = null!;
 
 	/// <summary>
 	/// The prompt to generate a response for
 	/// </summary>
-	[JsonPropertyName("prompt")]
+	[JsonPropertyName(Application.Prompt)]
 	public string Prompt { get; set; } = null!;
 
 	/// <summary>
 	/// Suffix for Fill-In-the-Middle generate
 	/// </summary>
-	[JsonPropertyName("suffix")]
+	[JsonPropertyName(Application.Suffix)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public string Suffix { get; set; } = null!;
 
@@ -37,28 +36,28 @@ public class GenerateRequest : OllamaRequest
 	/// Additional model parameters listed in the documentation for the
 	/// Modelfile such as temperature
 	/// </summary>
-	[JsonPropertyName("options")]
+	[JsonPropertyName(Application.Options)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public RequestOptions? Options { get; set; }
 
 	/// <summary>
 	/// Base64-encoded images (for multimodal models such as llava)
 	/// </summary>
-	[JsonPropertyName("images")]
+	[JsonPropertyName(Application.Images)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public string[]? Images { get; set; }
 
 	/// <summary>
 	/// System prompt to (overrides what is defined in the Modelfile)
 	/// </summary>
-	[JsonPropertyName("system")]
+	[JsonPropertyName(Application.System)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public string? System { get; set; }
 
 	/// <summary>
 	/// The full prompt or prompt template (overrides what is defined in the Modelfile)
 	/// </summary>
-	[JsonPropertyName("template")]
+	[JsonPropertyName(Application.Template)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public string? Template { get; set; }
 
@@ -66,21 +65,21 @@ public class GenerateRequest : OllamaRequest
 	/// The context parameter returned from a previous request to /generate,
 	/// this can be used to keep a short conversational memory
 	/// </summary>
-	[JsonPropertyName("context")]
+	[JsonPropertyName(Application.Context)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public long[]? Context { get; set; }
 
 	/// <summary>
 	/// Gets or sets the KeepAlive property, which decides how long a given model should stay loaded.
 	/// </summary>
-	[JsonPropertyName("keep_alive")]
+	[JsonPropertyName(Application.KeepAlive)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public string? KeepAlive { get; set; }
 
 	/// <summary>
 	/// Gets or sets the format to return a response in. Currently accepts "json" or JsonSchema or null.
 	/// </summary>
-	[JsonPropertyName("format")]
+	[JsonPropertyName(Application.Format)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public object? Format { get; set; }
 
@@ -88,14 +87,14 @@ public class GenerateRequest : OllamaRequest
 	/// If false the response will be returned as a single response object,
 	/// rather than a stream of objects
 	/// </summary>
-	[JsonPropertyName("stream")]
+	[JsonPropertyName(Application.Stream)]
 	public bool Stream { get; set; } = true;
 
 	/// <summary>
 	/// In some cases you may wish to bypass the templating system and provide
 	/// a full prompt. In this case, you can use the raw parameter to disable formatting.
 	/// </summary>
-	[JsonPropertyName("raw")]
+	[JsonPropertyName(Application.Raw)]
 	public bool Raw { get; set; }
 }
 
@@ -123,7 +122,10 @@ public class GenerateResponseStream
 		set
 		{
 			_createdAtString = value;
-			_createdAt = DateTimeOffset.TryParse(value, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.None, out var createdAt) ? createdAt : null;
+			_createdAt =
+				DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var createdAt)
+					? createdAt
+					: null;
 		}
 	}
 

--- a/src/Models/ListModels.cs
+++ b/src/Models/ListModels.cs
@@ -1,6 +1,6 @@
-using System;
 using System.Diagnostics;
 using System.Text.Json.Serialization;
+using OllamaSharp.Constants;
 
 namespace OllamaSharp.Models;
 
@@ -14,7 +14,7 @@ public class ListModelsResponse
 	/// <summary>
 	/// Gets or sets the array of models returned by the API.
 	/// </summary>
-	[JsonPropertyName("models")]
+	[JsonPropertyName(Application.Models)]
 	public Model[] Models { get; set; } = null!;
 }
 
@@ -27,31 +27,31 @@ public class Model
 	/// <summary>
 	/// Gets or sets the name of the model.
 	/// </summary>
-	[JsonPropertyName("name")]
+	[JsonPropertyName(Application.Name)]
 	public string Name { get; set; } = null!;
 
 	/// <summary>
 	/// Gets or sets the time the model was created or last modified.
 	/// </summary>
-	[JsonPropertyName("modified_at")]
+	[JsonPropertyName(Application.ModifiedAt)]
 	public DateTime ModifiedAt { get; set; }
 
 	/// <summary>
 	/// Gets or sets the size of the model file in bytes.
 	/// </summary>
-	[JsonPropertyName("size")]
+	[JsonPropertyName(Application.Size)]
 	public long Size { get; set; }
 
 	/// <summary>
 	/// Gets or sets a cryptographic hash of the model file.
 	/// </summary>
-	[JsonPropertyName("digest")]
+	[JsonPropertyName(Application.Digest)]
 	public string Digest { get; set; } = null!;
 
 	/// <summary>
 	/// Gets or sets additional details about the model.
 	/// </summary>
-	[JsonPropertyName("details")]
+	[JsonPropertyName(Application.Details)]
 	public Details Details { get; set; } = null!;
 }
 
@@ -63,36 +63,36 @@ public class Details
 	/// <summary>
 	/// Gets or sets the name of the parent model on which the model is based.
 	/// </summary>
-	[JsonPropertyName("parent_model")]
+	[JsonPropertyName(Application.ParentModel)]
 	public string? ParentModel { get; set; }
 
 	/// <summary>
 	/// Gets or sets the format of the model file.
 	/// </summary>
-	[JsonPropertyName("format")]
+	[JsonPropertyName(Application.Format)]
 	public string Format { get; set; } = null!;
 
 	/// <summary>
 	/// Gets or sets the family of the model.
 	/// </summary>
-	[JsonPropertyName("family")]
+	[JsonPropertyName(Application.Family)]
 	public string Family { get; set; } = null!;
 
 	/// <summary>
 	/// Gets or sets the families of the model.
 	/// </summary>
-	[JsonPropertyName("families")]
+	[JsonPropertyName(Application.Families)]
 	public string[]? Families { get; set; }
 
 	/// <summary>
 	/// Gets or sets the number of parameters in the model.
 	/// </summary>
-	[JsonPropertyName("parameter_size")]
+	[JsonPropertyName(Application.ParameterCount)]
 	public string ParameterSize { get; set; } = null!;
 
 	/// <summary>
 	/// Gets or sets the quantization level of the model.
 	/// </summary>
-	[JsonPropertyName("quantization_level")]
+	[JsonPropertyName(Application.QuantizationLevel)]
 	public string QuantizationLevel { get; set; } = null!;
 }

--- a/src/Models/ListModels.cs
+++ b/src/Models/ListModels.cs
@@ -87,7 +87,7 @@ public class Details
 	/// <summary>
 	/// Gets or sets the number of parameters in the model.
 	/// </summary>
-	[JsonPropertyName(Application.ParameterCount)]
+	[JsonPropertyName(Application.ParameterSize)]
 	public string ParameterSize { get; set; } = null!;
 
 	/// <summary>

--- a/src/Models/ListRunningModels.cs
+++ b/src/Models/ListRunningModels.cs
@@ -1,6 +1,6 @@
-using System;
 using System.Diagnostics;
 using System.Text.Json.Serialization;
+using OllamaSharp.Constants;
 
 namespace OllamaSharp.Models;
 
@@ -15,7 +15,7 @@ public class ListRunningModelsResponse
 	/// <summary>
 	/// An array of running models.
 	/// </summary>
-	[JsonPropertyName("models")]
+	[JsonPropertyName(Application.Models)]
 	public RunningModel[] RunningModels { get; set; } = null!;
 }
 
@@ -29,12 +29,12 @@ public class RunningModel : Model
 	/// <summary>
 	/// The amount of vram (in bytes) used by the model.
 	/// </summary>
-	[JsonPropertyName("size_vram")]
+	[JsonPropertyName(Application.SizeVram)]
 	public long SizeVram { get; set; }
 
 	/// <summary>
 	/// The time the model will be unloaded from memory.
 	/// </summary>
-	[JsonPropertyName("expires_at")]
+	[JsonPropertyName(Application.ExpiresAt)]
 	public DateTime ExpiresAt { get; set; }
 }

--- a/src/Models/OllamaOption.cs
+++ b/src/Models/OllamaOption.cs
@@ -1,3 +1,5 @@
+using OllamaSharp.Constants;
+
 namespace OllamaSharp.Models;
 
 /// <summary>
@@ -15,25 +17,25 @@ public class OllamaOption(string name)
 	/// Enable f16 key/value.
 	/// (Default: False)
 	/// </summary>
-	public static OllamaOption F16kv { get; } = new("f16_kv");
+	public static OllamaOption F16kv { get; } = new(Application.F16kv);
 
 	/// <summary>
 	/// The penalty to apply to tokens based on their frequency in the prompt.
 	/// (Default: 0.0)
 	/// </summary>
-	public static OllamaOption FrequencyPenalty { get; } = new("frequency_penalty");
+	public static OllamaOption FrequencyPenalty { get; } = new(Application.FrequencyPenalty);
 
 	/// <summary>
 	/// Return logits for all the tokens, not just the last one.
 	/// (Default: False)
 	/// </summary>
-	public static OllamaOption LogitsAll { get; } = new("logits_all");
+	public static OllamaOption LogitsAll { get; } = new(Application.LogitsAll);
 
 	/// <summary>
 	/// Enable low VRAM mode.
 	/// (Default: False)
 	/// </summary>
-	public static OllamaOption LowVram { get; } = new("low_vram");
+	public static OllamaOption LowVram { get; } = new(Application.LowVram);
 
 	/// <summary>
 	/// This option controls which GPU is used for small tensors. The overhead of
@@ -41,7 +43,7 @@ public class OllamaOption(string name)
 	/// use slightly more VRAM to store a scratch buffer for temporary results.
 	/// By default, GPU 0 is used.
 	/// </summary>
-	public static OllamaOption MainGpu { get; } = new("main_gpu");
+	public static OllamaOption MainGpu { get; } = new(Application.MainGpu);
 
 	/// <summary>
 	/// Alternative to the top_p, and aims to ensure a balance of quality and variety.min_p represents the minimum
@@ -49,13 +51,13 @@ public class OllamaOption(string name)
 	/// example, with min_p=0.05 and the most likely token having a probability of 0.9, logits with a value less
 	/// than 0.05*0.9=0.045 are filtered out. (Default: 0.0)
 	/// </summary>
-	public static OllamaOption MinP { get; } = new("min_p");
+	public static OllamaOption MinP { get; } = new(Application.MinP);
 
 	/// <summary>
 	/// Enable Mirostat sampling for controlling perplexity.
 	/// (default: 0, 0 = disabled, 1 = Mirostat, 2 = Mirostat 2.0)
 	/// </summary>
-	public static OllamaOption MiroStat { get; } = new("mirostat");
+	public static OllamaOption MiroStat { get; } = new(Application.MiroStat);
 
 	/// <summary>
 	/// Influences how quickly the algorithm responds to feedback from the
@@ -63,56 +65,56 @@ public class OllamaOption(string name)
 	/// while a higher learning rate will make the algorithm more responsive.
 	/// (Default: 0.1)
 	/// </summary>
-	public static OllamaOption MiroStatEta { get; } = new("mirostat_eta");
+	public static OllamaOption MiroStatEta { get; } = new(Application.MiroStatEta);
 
 	/// <summary>
 	/// Controls the balance between coherence and diversity of the output.
 	/// A lower value will result in more focused and coherent text.
 	/// (Default: 5.0)
 	/// </summary>
-	public static OllamaOption MiroStatTau { get; } = new("mirostat_tau");
+	public static OllamaOption MiroStatTau { get; } = new(Application.MiroStatTau);
 
 	/// <summary>
 	///  Enable NUMA support.
 	/// (Default: False)
 	/// </summary>
-	public static OllamaOption Numa { get; } = new("numa");
+	public static OllamaOption Numa { get; } = new(Application.Numa);
 
 	/// <summary>
 	/// Prompt processing maximum batch size.
 	/// (Default: 512)
 	/// </summary>
-	public static OllamaOption NumBatch { get; } = new("num_batch");
+	public static OllamaOption NumBatch { get; } = new(Application.NumBatch);
 
 	/// <summary>
 	/// Sets the size of the context window used to generate the next token.
 	/// (Default: 2048)
 	/// </summary>
-	public static OllamaOption NumCtx { get; } = new("num_ctx");
+	public static OllamaOption NumCtx { get; } = new(Application.NumCtx);
 
 	/// <summary>
 	/// The number of layers to send to the GPU(s). On macOS it defaults to
 	/// 1 to enable metal support, 0 to disable.
 	/// </summary>
-	public static OllamaOption NumGpu { get; } = new("num_gpu");
+	public static OllamaOption NumGpu { get; } = new(Application.NumGpu);
 
 	/// <summary>
 	/// The number of GQA groups in the transformer layer. Required for some
 	/// models, for example it is 8 for llama2:70b
 	/// </summary>
-	public static OllamaOption NumGqa { get; } = new("num_gqa");
+	public static OllamaOption NumGqa { get; } = new(Application.NumGqa);
 
 	/// <summary>
 	/// Number of tokens to keep from the initial prompt.
 	/// (Default: 4, -1 = all)
 	/// </summary>
-	public static OllamaOption NumKeep { get; } = new("num_keep");
+	public static OllamaOption NumKeep { get; } = new(Application.NumKeep);
 
 	/// <summary>
 	/// Maximum number of tokens to predict when generating text.
 	/// (Default: 128, -1 = infinite generation, -2 = fill context)
 	/// </summary>
-	public static OllamaOption NumPredict { get; } = new("num_predict");
+	public static OllamaOption NumPredict { get; } = new(Application.NumPredict);
 
 	/// <summary>
 	/// Sets the number of threads to use during computation. By default,
@@ -120,85 +122,85 @@ public class OllamaOption(string name)
 	/// It is recommended to set this value to the number of physical CPU cores
 	/// your system has (as opposed to the logical number of cores).
 	/// </summary>
-	public static OllamaOption NumThread { get; } = new("num_thread");
+	public static OllamaOption NumThread { get; } = new(Application.NumThread);
 
 	/// <summary>
 	/// Penalize newline tokens (Default: True)
 	/// </summary>
-	public static OllamaOption PenalizeNewline { get; } = new("penalize_newline");
+	public static OllamaOption PenalizeNewline { get; } = new(Application.PenalizeNewline);
 
 	/// <summary>
 	/// The penalty to apply to tokens based on their presence in the prompt.
 	/// (Default: 0.0)
 	/// </summary>
-	public static OllamaOption PresencePenalty { get; } = new("presence_penalty");
+	public static OllamaOption PresencePenalty { get; } = new(Application.PresencePenalty);
 
 	/// <summary>
 	/// Sets how far back for the model to look back to prevent repetition.
 	/// (Default: 64, 0 = disabled, -1 = num_ctx)
 	/// </summary>
-	public static OllamaOption RepeatLastN { get; } = new("repeat_last_n");
+	public static OllamaOption RepeatLastN { get; } = new(Application.RepeatLastN);
 
 	/// <summary>
 	/// Sets how strongly to penalize repetitions.
 	/// A higher value (e.g., 1.5) will penalize repetitions more strongly,
 	/// while a lower value (e.g., 0.9) will be more lenient. (Default: 1.1)
 	/// </summary>
-	public static OllamaOption RepeatPenalty { get; } = new("repeat_penalty");
+	public static OllamaOption RepeatPenalty { get; } = new(Application.RepeatPenalty);
 
 	/// <summary>
 	/// Sets the random number seed to use for generation.
 	/// Setting this to a specific number will make the model generate the same
 	/// text for the same prompt. (Default: 0)
 	/// </summary>
-	public static OllamaOption Seed { get; } = new("seed");
+	public static OllamaOption Seed { get; } = new(Application.Seed);
 
 	/// <summary>
 	/// Sets the stop sequences to use. When this pattern is encountered the
 	/// LLM will stop generating text and return. Multiple stop patterns may
 	/// be set by specifying multiple separate stop parameters in a modelfile.
 	/// </summary>
-	public static OllamaOption Stop { get; } = new("stop");
+	public static OllamaOption Stop { get; } = new(Application.Stop);
 
 	/// <summary>
 	/// The temperature of the model. Increasing the temperature will make the
 	/// model answer more creatively. (Default: 0.8)
 	/// </summary>
-	public static OllamaOption Temperature { get; } = new("temperature");
+	public static OllamaOption Temperature { get; } = new(Application.Temperature);
 
 	/// <summary>
 	/// Tail free sampling is used to reduce the impact of less probable
 	/// tokens from the output. A higher value (e.g., 2.0) will reduce the
 	/// impact more, while a value of 1.0 disables this setting. (default: 1)
 	/// </summary>
-	public static OllamaOption TfsZ { get; } = new("tfs_z");
+	public static OllamaOption TfsZ { get; } = new(Application.TfsZ);
 
 	/// <summary>
 	/// Reduces the probability of generating nonsense. A higher value
 	/// (e.g. 100) will give more diverse answers, while a lower value (e.g. 10)
 	/// will be more conservative. (Default: 40)
 	/// </summary>
-	public static OllamaOption TopK { get; } = new("top_k");
+	public static OllamaOption TopK { get; } = new(Application.TopK);
 
 	/// <summary>
 	/// Works together with top-k. A higher value (e.g., 0.95) will lead to
 	/// more diverse text, while a lower value (e.g., 0.5) will generate more
 	/// focused and conservative text. (Default: 0.9)
 	/// </summary>
-	public static OllamaOption TopP { get; } = new("top_p");
+	public static OllamaOption TopP { get; } = new(Application.TopP);
 
 	/// <summary>
 	/// The typical-p value to use for sampling. Locally Typical Sampling implementation described in the paper
 	/// https://arxiv.org/abs/2202.00666. (Default: 1.0)
 	/// </summary>
-	public static OllamaOption TypicalP { get; } = new("typical_p");
+	public static OllamaOption TypicalP { get; } = new(Application.TypicalP);
 
 	/// <summary>
 	/// Lock the model in memory to prevent swapping. This can improve
 	/// performance, but it uses more RAM and may slow down loading.
 	/// (Default: False)
 	/// </summary>
-	public static OllamaOption UseMlock { get; } = new("use_mlock");
+	public static OllamaOption UseMlock { get; } = new(Application.UseMlock);
 
 	/// <summary>
 	/// Models are mapped into memory by default, which allows the system to
@@ -207,11 +209,11 @@ public class OllamaOption(string name)
 	/// bigger than your RAM, turning off mmap stops it from loading.
 	/// (Default: True)
 	/// </summary>
-	public static OllamaOption UseMmap { get; } = new("use_mmap");
+	public static OllamaOption UseMmap { get; } = new(Application.UseMmap);
 
 	/// <summary>
 	/// Load only the vocabulary, not the weights.
 	/// (Default: False)
 	/// </summary>
-	public static OllamaOption VocabOnly { get; } = new("vocab_only");
+	public static OllamaOption VocabOnly { get; } = new(Application.VocabOnly);
 }

--- a/src/Models/PullModel.cs
+++ b/src/Models/PullModel.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using OllamaSharp.Constants;
 
 namespace OllamaSharp.Models;
 
@@ -13,21 +14,21 @@ public class PullModelRequest : OllamaRequest
 	/// <summary>
 	/// Gets or sets the name of the model to pull.
 	/// </summary>
-	[JsonPropertyName("model")]
+	[JsonPropertyName(Application.Model)]
 	public string? Model { get; set; }
 
 	/// <summary>
 	/// Gets or sets a value indicating whether to allow insecure connections to the library.
 	/// Only use this if you are pulling from your own library during development.
 	/// </summary>
-	[JsonPropertyName("insecure")]
+	[JsonPropertyName(Application.Insecure)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public bool? Insecure { get; set; }
 
 	/// <summary>
 	/// Gets or sets a value indicating whether to stream the response.
 	/// </summary>
-	[JsonPropertyName("stream")]
+	[JsonPropertyName(Application.Stream)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public bool? Stream { get; set; }
 }
@@ -40,25 +41,25 @@ public class PullModelResponse
 	/// <summary>
 	/// Gets or sets the status of the pull operation.
 	/// </summary>
-	[JsonPropertyName("status")]
+	[JsonPropertyName(Application.Status)]
 	public string Status { get; set; } = null!;
 
 	/// <summary>
 	/// Gets or sets the hash of the model file.
 	/// </summary>
-	[JsonPropertyName("digest")]
+	[JsonPropertyName(Application.Digest)]
 	public string Digest { get; set; } = null!;
 
 	/// <summary>
 	/// Gets or sets the total number of bytes to pull.
 	/// </summary>
-	[JsonPropertyName("total")]
+	[JsonPropertyName(Application.Total)]
 	public long Total { get; set; }
 
 	/// <summary>
 	/// Gets or sets the number of bytes pulled so far.
 	/// </summary>
-	[JsonPropertyName("completed")]
+	[JsonPropertyName(Application.Completed)]
 	public long Completed { get; set; }
 
 	/// <summary>

--- a/src/Models/PushModel.cs
+++ b/src/Models/PushModel.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using OllamaSharp.Constants;
 
 namespace OllamaSharp.Models;
 
@@ -11,21 +12,21 @@ public class PushModelRequest : OllamaRequest
 	/// <summary>
 	/// Gets or sets the name of the model to push in the form of namespace/model:tag.
 	/// </summary>
-	[JsonPropertyName("model")]
+	[JsonPropertyName(Application.Model)]
 	public string? Model { get; set; }
 
 	/// <summary>
 	/// Gets or sets a value indicating whether to allow insecure connections to the library.
 	/// Only use this if you are pulling from your own library during development.
 	/// </summary>
-	[JsonPropertyName("insecure")]
+	[JsonPropertyName(Application.Insecure)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public bool? Insecure { get; set; }
 
 	/// <summary>
 	/// Gets or sets a value indicating whether to stream the response.
 	/// </summary>
-	[JsonPropertyName("stream")]
+	[JsonPropertyName(Application.Stream)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public bool? Stream { get; set; }
 }
@@ -38,18 +39,18 @@ public class PushModelResponse
 	/// <summary>
 	/// Gets or sets the status of the push operation.
 	/// </summary>
-	[JsonPropertyName("status")]
+	[JsonPropertyName(Application.Status)]
 	public string Status { get; set; } = null!;
 
 	/// <summary>
 	/// Gets or sets the hash of the model file.
 	/// </summary>
-	[JsonPropertyName("digest")]
+	[JsonPropertyName(Application.Digest)]
 	public string Digest { get; set; } = null!;
 
 	/// <summary>
 	/// Gets or sets the total number of bytes to push.
 	/// </summary>
-	[JsonPropertyName("total")]
+	[JsonPropertyName(Application.Total)]
 	public int Total { get; set; }
 }

--- a/src/Models/RequestOptions.cs
+++ b/src/Models/RequestOptions.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using OllamaSharp.Constants;
 
 namespace OllamaSharp.Models;
 
@@ -11,7 +12,7 @@ public class RequestOptions
 	/// Enable Mirostat sampling for controlling perplexity.
 	/// (default: 0, 0 = disabled, 1 = Mirostat, 2 = Mirostat 2.0)
 	/// </summary>
-	[JsonPropertyName("mirostat")]
+	[JsonPropertyName(Application.MiroStat)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public int? MiroStat { get; set; }
 
@@ -21,7 +22,7 @@ public class RequestOptions
 	/// while a higher learning rate will make the algorithm more responsive.
 	/// (Default: 0.1)
 	/// </summary>
-	[JsonPropertyName("mirostat_eta")]
+	[JsonPropertyName(Application.MiroStatEta)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public float? MiroStatEta { get; set; }
 
@@ -30,7 +31,7 @@ public class RequestOptions
 	/// A lower value will result in more focused and coherent text.
 	/// (Default: 5.0)
 	/// </summary>
-	[JsonPropertyName("mirostat_tau")]
+	[JsonPropertyName(Application.MiroStatTau)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public float? MiroStatTau { get; set; }
 
@@ -38,7 +39,7 @@ public class RequestOptions
 	/// Sets the size of the context window used to generate the next token.
 	/// (Default: 2048)
 	/// </summary>
-	[JsonPropertyName("num_ctx")]
+	[JsonPropertyName(Application.NumCtx)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public int? NumCtx { get; set; }
 
@@ -46,7 +47,7 @@ public class RequestOptions
 	/// The number of GQA groups in the transformer layer. Required for some
 	/// models, for example it is 8 for llama2:70b
 	/// </summary>
-	[JsonPropertyName("num_gqa")]
+	[JsonPropertyName(Application.NumGqa)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public int? NumGqa { get; set; }
 
@@ -54,7 +55,7 @@ public class RequestOptions
 	/// The number of layers to send to the GPU(s). On macOS it defaults to
 	/// 1 to enable metal support, 0 to disable.
 	/// </summary>
-	[JsonPropertyName("num_gpu")]
+	[JsonPropertyName(Application.NumGpu)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public int? NumGpu { get; set; }
 
@@ -64,7 +65,7 @@ public class RequestOptions
 	/// use slightly more VRAM to store a scratch buffer for temporary results.
 	/// By default, GPU 0 is used.
 	/// </summary>
-	[JsonPropertyName("main_gpu")]
+	[JsonPropertyName(Application.MainGpu)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public int? MainGpu { get; set; }
 
@@ -72,7 +73,7 @@ public class RequestOptions
 	/// Prompt processing maximum batch size.
 	/// (Default: 512)
 	/// </summary>
-	[JsonPropertyName("num_batch")]
+	[JsonPropertyName(Application.NumBatch)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public int? NumBatch { get; set; }
 
@@ -82,7 +83,7 @@ public class RequestOptions
 	/// It is recommended to set this value to the number of physical CPU cores
 	/// your system has (as opposed to the logical number of cores).
 	/// </summary>
-	[JsonPropertyName("num_thread")]
+	[JsonPropertyName(Application.NumThread)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public int? NumThread { get; set; }
 
@@ -90,7 +91,7 @@ public class RequestOptions
 	/// Number of tokens to keep from the initial prompt.
 	/// (Default: 4, -1 = all)
 	/// </summary>
-	[JsonPropertyName("num_keep")]
+	[JsonPropertyName(Application.NumKeep)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public int? NumKeep { get; set; }
 
@@ -98,7 +99,7 @@ public class RequestOptions
 	/// Sets how far back for the model to look back to prevent repetition.
 	/// (Default: 64, 0 = disabled, -1 = num_ctx)
 	/// </summary>
-	[JsonPropertyName("repeat_last_n")]
+	[JsonPropertyName(Application.RepeatLastN)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public int? RepeatLastN { get; set; }
 
@@ -107,7 +108,7 @@ public class RequestOptions
 	/// A higher value (e.g., 1.5) will penalize repetitions more strongly,
 	/// while a lower value (e.g., 0.9) will be more lenient. (Default: 1.1)
 	/// </summary>
-	[JsonPropertyName("repeat_penalty")]
+	[JsonPropertyName(Application.RepeatPenalty)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public float? RepeatPenalty { get; set; }
 
@@ -115,7 +116,7 @@ public class RequestOptions
 	/// The penalty to apply to tokens based on their presence in the prompt.
 	/// (Default: 0.0)
 	/// </summary>
-	[JsonPropertyName("presence_penalty")]
+	[JsonPropertyName(Application.PresencePenalty)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public float? PresencePenalty { get; set; }
 
@@ -123,7 +124,7 @@ public class RequestOptions
 	/// The penalty to apply to tokens based on their frequency in the prompt.
 	/// (Default: 0.0)
 	/// </summary>
-	[JsonPropertyName("frequency_penalty")]
+	[JsonPropertyName(Application.FrequencyPenalty)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public float? FrequencyPenalty { get; set; }
 
@@ -131,7 +132,7 @@ public class RequestOptions
 	/// The temperature of the model. Increasing the temperature will make the
 	/// model answer more creatively. (Default: 0.8)
 	/// </summary>
-	[JsonPropertyName("temperature")]
+	[JsonPropertyName(Application.Temperature)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public float? Temperature { get; set; }
 
@@ -140,7 +141,7 @@ public class RequestOptions
 	/// Setting this to a specific number will make the model generate the same
 	/// text for the same prompt. (Default: 0)
 	/// </summary>
-	[JsonPropertyName("seed")]
+	[JsonPropertyName(Application.Seed)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public int? Seed { get; set; }
 
@@ -149,7 +150,7 @@ public class RequestOptions
 	/// LLM will stop generating text and return. Multiple stop patterns may
 	/// be set by specifying multiple separate stop parameters in a modelfile.
 	/// </summary>
-	[JsonPropertyName("stop")]
+	[JsonPropertyName(Application.Stop)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public string[]? Stop { get; set; }
 
@@ -158,7 +159,7 @@ public class RequestOptions
 	/// tokens from the output. A higher value (e.g., 2.0) will reduce the
 	/// impact more, while a value of 1.0 disables this setting. (default: 1)
 	/// </summary>
-	[JsonPropertyName("tfs_z")]
+	[JsonPropertyName(Application.TfsZ)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public float? TfsZ { get; set; }
 
@@ -166,7 +167,7 @@ public class RequestOptions
 	/// Maximum number of tokens to predict when generating text.
 	/// (Default: 128, -1 = infinite generation, -2 = fill context)
 	/// </summary>
-	[JsonPropertyName("num_predict")]
+	[JsonPropertyName(Application.NumPredict)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public int? NumPredict { get; set; }
 
@@ -175,7 +176,7 @@ public class RequestOptions
 	/// (e.g. 100) will give more diverse answers, while a lower value (e.g. 10)
 	/// will be more conservative. (Default: 40)
 	/// </summary>
-	[JsonPropertyName("top_k")]
+	[JsonPropertyName(Application.TopK)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public int? TopK { get; set; }
 
@@ -184,7 +185,7 @@ public class RequestOptions
 	/// more diverse text, while a lower value (e.g., 0.5) will generate more
 	/// focused and conservative text. (Default: 0.9)
 	/// </summary>
-	[JsonPropertyName("top_p")]
+	[JsonPropertyName(Application.TopP)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public float? TopP { get; set; }
 
@@ -194,7 +195,7 @@ public class RequestOptions
 	/// example, with min_p=0.05 and the most likely token having a probability of 0.9, logits with a value less
 	/// than 0.05*0.9=0.045 are filtered out. (Default: 0.0)
 	/// </summary>
-	[JsonPropertyName("min_p")]
+	[JsonPropertyName(Application.MinP)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public float? MinP { get; set; }
 
@@ -202,14 +203,14 @@ public class RequestOptions
 	/// The typical-p value to use for sampling. Locally Typical Sampling implementation described in the paper
 	/// https://arxiv.org/abs/2202.00666. (Default: 1.0)
 	/// </summary>
-	[JsonPropertyName("typical_p")]
+	[JsonPropertyName(Application.TypicalP)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public float? TypicalP { get; set; }
 
 	/// <summary>
 	/// Penalize newline tokens (Default: True)
 	/// </summary>
-	[JsonPropertyName("penalize_newline")]
+	[JsonPropertyName(Application.PenalizeNewline)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public bool? PenalizeNewline { get; set; }
 
@@ -220,7 +221,7 @@ public class RequestOptions
 	/// bigger than your RAM, turning off mmap stops it from loading.
 	/// (Default: True)
 	/// </summary>
-	[JsonPropertyName("use_mmap")]
+	[JsonPropertyName(Application.UseMmap)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public bool? UseMmap { get; set; }
 
@@ -229,7 +230,7 @@ public class RequestOptions
 	/// performance, but it uses more RAM and may slow down loading.
 	/// (Default: False)
 	/// </summary>
-	[JsonPropertyName("use_mlock")]
+	[JsonPropertyName(Application.UseMlock)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public bool? UseMlock { get; set; }
 
@@ -237,7 +238,7 @@ public class RequestOptions
 	/// Enable low VRAM mode.
 	/// (Default: False)
 	/// </summary>
-	[JsonPropertyName("low_vram")]
+	[JsonPropertyName(Application.LowVram)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public bool? LowVram { get; set; }
 
@@ -245,7 +246,7 @@ public class RequestOptions
 	/// Enable f16 key/value.
 	/// (Default: False)
 	/// </summary>
-	[JsonPropertyName("f16_kv")]
+	[JsonPropertyName(Application.F16kv)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public bool? F16kv { get; set; }
 
@@ -253,7 +254,7 @@ public class RequestOptions
 	/// Return logits for all the tokens, not just the last one.
 	/// (Default: False)
 	/// </summary>
-	[JsonPropertyName("logits_all")]
+	[JsonPropertyName(Application.LogitsAll)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public bool? LogitsAll { get; set; }
 
@@ -261,7 +262,7 @@ public class RequestOptions
 	/// Load only the vocabulary, not the weights.
 	/// (Default: False)
 	/// </summary>
-	[JsonPropertyName("vocab_only")]
+	[JsonPropertyName(Application.VocabOnly)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public bool? VocabOnly { get; set; }
 
@@ -269,7 +270,7 @@ public class RequestOptions
 	///  Enable NUMA support.
 	/// (Default: False)
 	/// </summary>
-	[JsonPropertyName("numa")]
+	[JsonPropertyName(Application.Numa)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public bool? Numa { get; set; }
 }

--- a/src/Models/ShowModel.cs
+++ b/src/Models/ShowModel.cs
@@ -1,5 +1,5 @@
-using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using OllamaSharp.Constants;
 
 namespace OllamaSharp.Models;
 
@@ -13,7 +13,7 @@ public class ShowModelRequest : OllamaRequest
 	/// <summary>
 	/// Gets or sets the name of the model to show.
 	/// </summary>
-	[JsonPropertyName("model")]
+	[JsonPropertyName(Application.Model)]
 	public string? Model { get; set; }
 }
 
@@ -25,49 +25,49 @@ public class ShowModelResponse
 	/// <summary>
 	/// Gets or sets the license for the model.
 	/// </summary>
-	[JsonPropertyName("license")]
+	[JsonPropertyName(Application.License)]
 	public string? License { get; set; }
 
 	/// <summary>
 	/// Gets or sets the Modelfile for the model.
 	/// </summary>
-	[JsonPropertyName("modelfile")]
+	[JsonPropertyName(Application.ModelFile)]
 	public string? Modelfile { get; set; }
 
 	/// <summary>
 	/// Gets or sets the parameters for the model.
 	/// </summary>
-	[JsonPropertyName("parameters")]
+	[JsonPropertyName(Application.Parameters)]
 	public string? Parameters { get; set; }
 
 	/// <summary>
 	/// Gets or sets the template for the model.
 	/// </summary>
-	[JsonPropertyName("template")]
+	[JsonPropertyName(Application.Template)]
 	public string? Template { get; set; }
 
 	/// <summary>
 	/// Gets or sets the system prompt for the model.
 	/// </summary>
-	[JsonPropertyName("system")]
+	[JsonPropertyName(Application.System)]
 	public string? System { get; set; }
 
 	/// <summary>
 	/// Gets or sets additional details about the model.
 	/// </summary>
-	[JsonPropertyName("details")]
+	[JsonPropertyName(Application.Details)]
 	public Details Details { get; set; } = null!;
 
 	/// <summary>
 	/// Gets or sets extra information about the model.
 	/// </summary>
-	[JsonPropertyName("model_info")]
+	[JsonPropertyName(Application.ModelInfo)]
 	public ModelInfo Info { get; set; } = null!;
 
 	/// <summary>
 	/// Gets or sets extra information about the projector.
 	/// </summary>
-	[JsonPropertyName("projector_info")]
+	[JsonPropertyName(Application.Projector)]
 	public ProjectorInfo? Projector { get; set; } = null!;
 }
 
@@ -79,25 +79,25 @@ public class ModelInfo
 	/// <summary>
 	/// Gets or sets the architecture of the model.
 	/// </summary>
-	[JsonPropertyName("general.architecture")]
+	[JsonPropertyName(Application.GeneralArchitecture)]
 	public string? Architecture { get; set; }
 
 	/// <summary>
 	/// Gets or sets the file type of the model.
 	/// </summary>
-	[JsonPropertyName("general.file_type")]
+	[JsonPropertyName(Application.GeneralFileType)]
 	public int? FileType { get; set; }
 
 	/// <summary>
 	/// Gets or sets the parameter count of the model.
 	/// </summary>
-	[JsonPropertyName("general.parameter_count")]
+	[JsonPropertyName(Application.GeneralParameterCount)]
 	public long? ParameterCount { get; set; }
 
 	/// <summary>
 	/// Gets or sets the quantization version of the model.
 	/// </summary>
-	[JsonPropertyName("general.quantization_version")]
+	[JsonPropertyName(Application.GeneralQuantizationVersion)]
 	public int? QuantizationVersion { get; set; }
 
 	/// <summary>


### PR DESCRIPTION
#166 ended up moving a large chunk of the `JsonPropertyNames` over to constants while I was finding and combing other magic strings in the `OllamaApiClient`. This moves the rest of the strings in the model classes over to the constants to keep everything consistent.