### PR TITLE
OpenTelemetry support

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,57 @@ private static IChatClient CreateChatClient(Arguments arguments)
 > [!NOTE]
 > `IOllamaApiClient` provides many Ollama specific methods that `IChatClient` and `IEmbeddingGenerator` miss. Because these are abstractions, `IChatClient` and `IEmbeddingGenerator` will never implement the full Ollama API specification. However, `OllamaApiClient` implements three interfaces: the native `IOllamaApiClient` and Microsoft `IChatClient` and `IEmbeddingGenerator<string, Embedding<float>>` which allows you to cast it to any of these two interfaces as you need them at any time.
 
+## Observability with OpenTelemetry
+
+> Note: The OllamaSharp OpenTelemetry integration is still in development, currently it only covers the Chat API.
+
+OllamaSharp is instrumented with distributed tracing and metrics using .NET [tracing](https://learn.microsoft.com/dotnet/core/diagnostics/distributed-tracing)
+and [metrics](https://learn.microsoft.com/dotnet/core/diagnostics/metrics-instrumentation) API and supports [OpenTelemetry](https://learn.microsoft.com/dotnet/core/diagnostics/observability-with-otel).
+
+OllamaSharp instrumentation follows [OpenTelemetry Semantic Conventions for Generative AI systems](https://github.com/open-telemetry/semantic-conventions/tree/main/docs/gen-ai).
+
+### How to enable
+
+The instrumentation is **experimental** - volume and semantics of the telemetry items may change.
+
+To enable the instrumentation:
+
+1. Set instrumentation feature-flag using one of the following options:
+
+   - set the `OLLAMASHARP_EXPERIMENTAL_ENABLE_OPEN_TELEMETRY` environment variable to `"true"`
+   - set the `OllamaSharp.Experimental.EnableOpenTelemetry` context switch to true in your application code when application
+     is starting and before initializing any OllamaSharp clients. For example:
+
+     ```csharp
+     AppContext.SetSwitch("OllamaSharp.Experimental.EnableOpenTelemetry", true);
+     ```
+
+2. Enable OllamaSharp telemetry:
+
+   ```csharp
+   builder.Services.AddOpenTelemetry()
+       .WithTracing(b =>
+       {
+           b.AddSource("OllamaSharp.*")
+             ...
+            .AddOtlpExporter();
+       })
+       .WithMetrics(b =>
+       {
+           b.AddMeter("OllamaSharp.*")
+            ...
+            .AddOtlpExporter();
+       });
+   ```
+
+   Distributed tracing is enabled with `AddSource("OllamaSharp.*")` which tells OpenTelemetry to listen to all [ActivitySources](https://learn.microsoft.com/dotnet/api/system.diagnostics.activitysource) with names starting with `OllamaSharp.*`.
+
+   Similarly, metrics are configured with `AddMeter("OllamaSharp.*")` which enables all OllamaSharp-related [Meters](https://learn.microsoft.com/dotnet/api/system.diagnostics.metrics.meter).
+
+Consider enabling [HTTP client instrumentation](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Http) to see all HTTP client
+calls made by your application including those done by the OllamaSharp.
+Check out [OpenTelemetry documentation](https://opentelemetry.io/docs/languages/net/getting-started/) for more details.
+
 ## Credits
 
 The icon and name were reused from the amazing [Ollama project](https://github.com/jmorganca/ollama).

--- a/src/OllamaSharp.csproj
+++ b/src/OllamaSharp.csproj
@@ -44,5 +44,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0" />
 		<PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.1.0-preview.1.25064.3" />
+		<PackageReference Include="System.ClientModel" Version="1.2.1" />
+		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.1" />
 	</ItemGroup>
 </Project>

--- a/src/Telemetry/AppContextSwitchHelper.cs
+++ b/src/Telemetry/AppContextSwitchHelper.cs
@@ -1,0 +1,31 @@
+namespace OllamaSharp.Telemetry;
+
+internal static class AppContextSwitchHelper
+{
+	/// <summary>
+	/// Determines if either an AppContext switch or its corresponding Environment Variable is set
+	/// </summary>
+	/// <param name="appContextSwitchName">Name of the AppContext switch.</param>
+	/// <param name="environmentVariableName">Name of the Environment variable.</param>
+	/// <returns>If the AppContext switch has been set, returns the value of the switch.
+	/// If the AppContext switch has not been set, returns the value of the environment variable.
+	/// False if neither is set.
+	/// </returns>
+	public static bool GetConfigValue(string appContextSwitchName, string environmentVariableName)
+	{
+		// First check for the AppContext switch, giving it priority over the environment variable.
+		if (AppContext.TryGetSwitch(appContextSwitchName, out var value))
+		{
+			return value;
+		}
+		// AppContext switch wasn't used. Check the environment variable.
+		var envVar = Environment.GetEnvironmentVariable(environmentVariableName);
+		if (envVar != null && (envVar.Equals("true", StringComparison.OrdinalIgnoreCase) || envVar.Equals("1")))
+		{
+			return true;
+		}
+
+		// Default to false.
+		return false;
+	}
+}

--- a/src/Telemetry/OpenTelemetryConstants.cs
+++ b/src/Telemetry/OpenTelemetryConstants.cs
@@ -1,0 +1,38 @@
+namespace OllamaSharp.Telemetry;
+
+internal class OpenTelemetryConstants
+{
+	// follow OpenTelemetry GenAI semantic conventions:
+	// https://github.com/open-telemetry/semantic-conventions/tree/v1.27.0/docs/gen-ai
+
+	public const string ERROR_TYPE_KEY = "error.type";
+	public const string SERVER_ADDRESS_KEY = "server.address";
+	public const string SERVER_PORT_KEY = "server.port";
+
+	public const string GEN_AI_CLIENT_OPERATION_DURATION_METRIC_NAME = "gen_ai.client.operation.duration";
+	public const string GEN_AI_CLIENT_TOKEN_USAGE_METRIC_NAME = "gen_ai.client.token.usage";
+
+	public const string GEN_AI_OPERATION_NAME_KEY = "gen_ai.operation.name";
+
+	public const string GEN_AI_REQUEST_MAX_TOKENS_KEY = "gen_ai.request.max_tokens";
+	public const string GEN_AI_REQUEST_MODEL_KEY = "gen_ai.request.model";
+	public const string GEN_AI_REQUEST_TEMPERATURE_KEY = "gen_ai.request.temperature";
+	public const string GEN_AI_REQUEST_TOP_P_KEY = "gen_ai.request.top_p";
+	public const string GEN_AI_REQUEST_TOP_K_KEY = "gen_ai.request.top_k";
+	public const string GEN_AI_REQUEST_PRESENCE_PENALTY_KEY = "gen_ai.request.presence_penalty";
+	public const string GEN_AI_REQUEST_STOP_SEQUENCES_KEY = "gen_ai.request.stop_sequences";
+
+	public const string GEN_AI_PROMPT_KEY = "gen_ai.prompt";
+
+	public const string GEN_AI_RESPONSE_ID_KEY = "gen_ai.response.id";
+	public const string GEN_AI_RESPONSE_FINISH_REASON_KEY = "gen_ai.response.finish_reasons";
+	public const string GEN_AI_RESPONSE_MODEL_KEY = "gen_ai.response.model";
+
+	public const string GEN_AI_SYSTEM_KEY = "gen_ai.system";
+	public const string GEN_AI_SYSTEM_VALUE = "ollamasharp";
+
+	public const string GEN_AI_TOKEN_TYPE_KEY = "gen_ai.token.type";
+
+	public const string GEN_AI_USAGE_INPUT_TOKENS_KEY = "gen_ai.usage.input_tokens";
+	public const string GEN_AI_USAGE_OUTPUT_TOKENS_KEY = "gen_ai.usage.output_tokens";
+}

--- a/src/Telemetry/OpenTelemetryScope.cs
+++ b/src/Telemetry/OpenTelemetryScope.cs
@@ -1,0 +1,191 @@
+using System.ClientModel;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using OllamaSharp.Models.Chat;
+
+using static OllamaSharp.Telemetry.OpenTelemetryConstants;
+
+namespace OllamaSharp.Telemetry;
+
+internal class OpenTelemetryScope : IDisposable
+{
+	private static readonly ActivitySource _chatSource = new("OllamaSharp.ChatClient");
+	private static readonly Meter _chatMeter = new("OllamaSharp.ChatClient");
+
+	// TODO: add explicit histogram buckets once System.Diagnostics.DiagnosticSource 9.0 is used
+	private static readonly Histogram<double> _duration = _chatMeter.CreateHistogram<double>(GEN_AI_CLIENT_OPERATION_DURATION_METRIC_NAME, "s", "Measures GenAI operation duration.");
+	private static readonly Histogram<long> _tokens = _chatMeter.CreateHistogram<long>(GEN_AI_CLIENT_TOKEN_USAGE_METRIC_NAME, "{token}", "Measures the number of input and output token used.");
+
+	private readonly string _operationName;
+	private readonly string _serverAddress;
+	private readonly int _serverPort;
+	private readonly string _requestModel;
+
+	private Stopwatch? _durationTime;
+	private Activity? _activity;
+	private TagList? _commonTags;
+
+	private OpenTelemetryScope(
+		string model, string operationName,
+		string serverAddress, int serverPort)
+	{
+		_requestModel = model;
+		_operationName = operationName;
+		_serverAddress = serverAddress;
+		_serverPort = serverPort;
+	}
+
+	private static bool IsChatEnabled => _chatSource.HasListeners() || _duration.Enabled;
+
+	public static OpenTelemetryScope? StartChat(string model, string operationName,
+		string serverAddress, int serverPort, ChatRequest options)
+	{
+		if (IsChatEnabled)
+		{
+			var scope = new OpenTelemetryScope(model, operationName, serverAddress, serverPort);
+			scope.StartChat(options);
+			return scope;
+		}
+
+		return null;
+	}
+
+	private void StartChat(ChatRequest options)
+	{
+		_durationTime = Stopwatch.StartNew();
+		_commonTags = new TagList
+		{
+			{ GEN_AI_SYSTEM_KEY, GEN_AI_SYSTEM_VALUE },
+			{ GEN_AI_REQUEST_MODEL_KEY, _requestModel },
+			{ SERVER_ADDRESS_KEY, _serverAddress },
+			{ SERVER_PORT_KEY, _serverPort },
+			{ GEN_AI_OPERATION_NAME_KEY, _operationName },
+		};
+
+		_activity = _chatSource.StartActivity(string.Concat(_operationName, " ", _requestModel), ActivityKind.Client);
+		if (_activity?.IsAllDataRequested == true)
+		{
+			RecordCommonAttributes();
+			SetActivityTagIfNotNull(GEN_AI_REQUEST_MAX_TOKENS_KEY, options?.Options?.NumPredict);
+			SetActivityTagIfNotNull(GEN_AI_REQUEST_TEMPERATURE_KEY, options?.Options?.Temperature);
+			SetActivityTagIfNotNull(GEN_AI_REQUEST_TOP_P_KEY, options?.Options?.TopP);
+			SetActivityTagIfNotNull(GEN_AI_REQUEST_TOP_K_KEY, options?.Options?.TopK);
+			SetActivityTagIfNotNull(GEN_AI_REQUEST_PRESENCE_PENALTY_KEY, options?.Options?.PresencePenalty);
+			SetActivityTagIfNotNull(GEN_AI_REQUEST_STOP_SEQUENCES_KEY, options?.Options?.Stop);
+		}
+
+		return;
+	}
+
+	public void RecordChatCompletion(ChatResponseStream? completion)
+	{
+		if (completion == null)
+		{
+			return;
+		}
+
+		var doneCompletion = completion as ChatDoneResponseStream;
+
+		RecordMetrics(completion.Model, null, doneCompletion?.PromptEvalCount, doneCompletion?.EvalCount);
+
+		if (_activity?.IsAllDataRequested == true)
+		{
+			SetActivityTagIfNotNull(GEN_AI_RESPONSE_MODEL_KEY, completion.Model);
+			SetActivityTagIfNotNull(GEN_AI_USAGE_INPUT_TOKENS_KEY, doneCompletion?.PromptEvalCount);
+			SetActivityTagIfNotNull(GEN_AI_USAGE_OUTPUT_TOKENS_KEY, doneCompletion?.EvalCount);
+		}
+	}
+
+	public void RecordException(Exception ex)
+	{
+		var errorType = GetErrorType(ex);
+		RecordMetrics(null, errorType, null, null);
+		if (_activity?.IsAllDataRequested == true)
+		{
+			_activity?.SetTag(ERROR_TYPE_KEY, errorType);
+			_activity?.SetStatus(ActivityStatusCode.Error, ex?.Message ?? errorType);
+		}
+	}
+
+	public void Dispose()
+	{
+		_activity?.Stop();
+	}
+
+	private void RecordCommonAttributes()
+	{
+		_activity?.SetTag(GEN_AI_SYSTEM_KEY, GEN_AI_SYSTEM_VALUE);
+		_activity?.SetTag(GEN_AI_REQUEST_MODEL_KEY, _requestModel);
+		_activity?.SetTag(SERVER_ADDRESS_KEY, _serverAddress);
+		_activity?.SetTag(SERVER_PORT_KEY, _serverPort);
+		_activity?.SetTag(GEN_AI_OPERATION_NAME_KEY, _operationName);
+	}
+
+	private void RecordMetrics(string? responseModel, string? errorType, int? inputTokensUsage, int? outputTokensUsage)
+	{
+		// tags is a struct, let's copy and modify them
+		var tags = _commonTags ?? new();
+
+		if (responseModel != null)
+		{
+			tags.Add(GEN_AI_RESPONSE_MODEL_KEY, responseModel);
+		}
+
+		if (inputTokensUsage != null)
+		{
+			var inputUsageTags = tags;
+			inputUsageTags.Add(GEN_AI_TOKEN_TYPE_KEY, "input");
+			_tokens.Record(inputTokensUsage.Value, inputUsageTags);
+		}
+
+		if (outputTokensUsage != null)
+		{
+			var outputUsageTags = tags;
+			outputUsageTags.Add(GEN_AI_TOKEN_TYPE_KEY, "output");
+			_tokens.Record(outputTokensUsage.Value, outputUsageTags);
+		}
+
+		if (errorType != null)
+		{
+			tags.Add(ERROR_TYPE_KEY, errorType);
+		}
+
+		_duration.Record(_durationTime!.Elapsed.TotalSeconds, tags);
+	}
+
+	private string? GetErrorType(Exception exception)
+	{
+		if (exception is ClientResultException requestFailedException)
+		{
+			// TODO when we start targeting .NET 8+ we should put
+			// requestFailedException.InnerException.HttpRequestError into error.type
+			return requestFailedException.Status.ToString();
+		}
+
+		return exception?.GetType()?.FullName;
+	}
+
+	private void SetActivityTagIfNotNull(string name, object? value)
+	{
+		if (value != null)
+		{
+			_activity?.SetTag(name, value);
+		}
+	}
+
+	private void SetActivityTagIfNotNull(string name, int? value)
+	{
+		if (value.HasValue)
+		{
+			_activity?.SetTag(name, value.Value);
+		}
+	}
+
+	private void SetActivityTagIfNotNull(string name, float? value)
+	{
+		if (value.HasValue)
+		{
+			_activity?.SetTag(name, value.Value);
+		}
+	}
+}

--- a/src/Telemetry/OpenTelemetrySource.cs
+++ b/src/Telemetry/OpenTelemetrySource.cs
@@ -1,0 +1,27 @@
+using OllamaSharp.Models.Chat;
+
+namespace OllamaSharp.Telemetry;
+
+internal class OpenTelemetrySource
+{
+	private const string CHAT_OPERATION_NAME = "chat";
+	private readonly bool _isOTelEnabled = AppContextSwitchHelper
+		.GetConfigValue("OllamaSharp.Experimental.EnableOpenTelemetry", "OLLAMASHARP_EXPERIMENTAL_ENABLE_OPEN_TELEMETRY");
+
+	private readonly string _serverAddress;
+	private readonly int _serverPort;
+
+	public OpenTelemetrySource(Uri endpoint)
+	{
+		_serverAddress = endpoint.Host;
+		_serverPort = endpoint.Port;
+	}
+
+	public OpenTelemetryScope? StartChatScope(ChatRequest completionsOptions)
+	{
+		return _isOTelEnabled
+			? OpenTelemetryScope.StartChat(completionsOptions.Model, CHAT_OPERATION_NAME, _serverAddress, _serverPort, completionsOptions)
+			: null;
+	}
+
+}


### PR DESCRIPTION
Fixes #185

This is heavily borrowed from the OpenAI implementation.

It focuses on tracing through the Chat/Chat Streaming part of the Ollama API, adding an opt-in activity source. If the feature isn't enabled (it's not by default) then the method calls are essentially noops.

Here's what it looks like in the Aspire dashboard. You can see the metrics in the trace from the request and response.

![image](https://github.com/user-attachments/assets/b8178aad-582e-4ad2-81ee-f1028844f2ed)

Included docs on how to use it.
