### PR TITLE
Support for keep_alive in MicrosoftAi ChatOptions

### DIFF
--- a/src/OllamaSharp/MicrosoftAi/AbstractionMapper.cs
+++ b/src/OllamaSharp/MicrosoftAi/AbstractionMapper.cs
@@ -112,6 +112,8 @@ internal static class AbstractionMapper
 		TryAddOllamaOption<bool?>(options, OllamaOption.UseMlock, v => request.Options.UseMlock = (bool?)v);
 		TryAddOllamaOption<bool?>(options, OllamaOption.UseMmap, v => request.Options.UseMmap = (bool?)v);
 		TryAddOllamaOption<bool?>(options, OllamaOption.VocabOnly, v => request.Options.VocabOnly = (bool?)v);
+		
+		TryAddOption<string?>(options, Application.KeepAlive, v => request.KeepAlive = (string?)v);
 
 		return request;
 	}
@@ -125,7 +127,12 @@ internal static class AbstractionMapper
 	/// <param name="optionSetter">The setter to set the Ollama option if available in the chat options</param>
 	private static void TryAddOllamaOption<T>(ChatOptions? microsoftChatOptions, OllamaOption option, Action<object?> optionSetter)
 	{
-		if ((microsoftChatOptions?.AdditionalProperties?.TryGetValue(option.Name, out var value) ?? false) && value is not null)
+		TryAddOption<T>(microsoftChatOptions, option.Name, optionSetter);
+	}
+	
+	private static void TryAddOption<T>(ChatOptions? microsoftChatOptions, string option, Action<object?> optionSetter)
+	{
+		if ((microsoftChatOptions?.AdditionalProperties?.TryGetValue(option, out var value) ?? false) && value is not null)
 			optionSetter(value);
 	}
 
@@ -445,7 +452,7 @@ internal static class AbstractionMapper
 
 		if (options?.AdditionalProperties is { } requestProps)
 		{
-			if (requestProps.TryGetValue(Application.KeepAlive, out long keepAlive))
+			if (requestProps.TryGetValue(Application.KeepAlive, out string? keepAlive))
 				request.KeepAlive = keepAlive;
 
 			if (requestProps.TryGetValue(Application.Truncate, out bool truncate))

--- a/src/OllamaSharp/Models/Embed.cs
+++ b/src/OllamaSharp/Models/Embed.cs
@@ -35,7 +35,7 @@ public class EmbedRequest : OllamaRequest
 	/// </summary>
 	[JsonPropertyName(Application.KeepAlive)]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-	public long? KeepAlive { get; set; }
+	public string? KeepAlive { get; set; }
 
 	/// <summary>
 	/// Truncates the end of each input to fit within context length.

--- a/test/AbstractionMapperTests.cs
+++ b/test/AbstractionMapperTests.cs
@@ -249,6 +249,20 @@ public class AbstractionMapperTests
 		}
 
 		[Test]
+		public void Maps_KeepAliveAll_From_AdditionalProperties()
+		{
+			var options = new ChatOptions
+			{
+				AdditionalProperties = []
+			};
+			options.AdditionalProperties["keep_alive"] = "60m";
+
+			var request = AbstractionMapper.ToOllamaSharpChatRequest([], options, false, JsonSerializerOptions.Default);
+
+			request.KeepAlive.ShouldBe("60m");
+		}
+
+		[Test]
 		public void Maps_All_Options_With_AdditionalProperties()
 		{
 			// Arrange
@@ -872,12 +886,12 @@ public class ToOllamaEmbedRequestMethod : AbstractionMapperTests
 		{
 			AdditionalProperties = []
 		};
-		options.AdditionalProperties["keep_alive"] = 123456789;
+		options.AdditionalProperties["keep_alive"] = "60m";
 		options.AdditionalProperties["truncate"] = true;
 
 		var request = AbstractionMapper.ToOllamaEmbedRequest([], options);
 
-		request.KeepAlive.ShouldBe(123456789);
+		request.KeepAlive.ShouldBe("60m");
 		request.Truncate.ShouldBe(true);
 	}
 }


### PR DESCRIPTION
I've added `keep_alive` to `ChatOptions`. It was already supported in `EmbeddingGenerationOptions`. 
Additionaly I've changed from long to string value of `keep_alive` in `EmbeddingGenerationOptions` to be consistent with Ollama API doc.