### PR TITLE
Add a schema transformer to the IChatClient implementation.

### DIFF
--- a/src/OllamaSharp/MicrosoftAi/AbstractionMapper.cs
+++ b/src/OllamaSharp/MicrosoftAi/AbstractionMapper.cs
@@ -17,7 +17,6 @@ internal static class AbstractionMapper
 	{
 		ConvertBooleanSchemas = true,
 		DisallowAdditionalProperties = true,
-		RequireAllProperties = true,
 	});
 
 	/// <summary>

--- a/test/AbstractionMapperTests.cs
+++ b/test/AbstractionMapperTests.cs
@@ -243,7 +243,7 @@ public class AbstractionMapperTests
 			tool.Function.Parameters.Properties["unit"].Description.ShouldBe("The unit to calculate the current temperature to");
 			tool.Function.Parameters.Properties["unit"].Enum.ShouldBeNull();
 			tool.Function.Parameters.Properties["unit"].Type.ShouldBe("string");
-			tool.Function.Parameters.Required.ShouldBe(["city", "unit"], ignoreOrder: true); // We're marking all parameters as required in the schema transformer
+			tool.Function.Parameters.Required.ShouldBe(["city"], ignoreOrder: true);
 			tool.Function.Parameters.Type.ShouldBe("object");
 			tool.Type.ShouldBe("function");
 		}

--- a/test/AbstractionMapperTests.cs
+++ b/test/AbstractionMapperTests.cs
@@ -243,7 +243,7 @@ public class AbstractionMapperTests
 			tool.Function.Parameters.Properties["unit"].Description.ShouldBe("The unit to calculate the current temperature to");
 			tool.Function.Parameters.Properties["unit"].Enum.ShouldBeNull();
 			tool.Function.Parameters.Properties["unit"].Type.ShouldBe("string");
-			tool.Function.Parameters.Required.ShouldBe(["city"], ignoreOrder: true); // AIJsonSchemaCreateOptions.RequireAllProperties is true by default.
+			tool.Function.Parameters.Required.ShouldBe(["city", "unit"], ignoreOrder: true); // We're marking all parameters as required in the schema transformer
 			tool.Function.Parameters.Type.ShouldBe("object");
 			tool.Type.ShouldBe("function");
 		}


### PR DESCRIPTION
Recent versions of Microsoft.Extensions.AI have removed certain on-by-default transformations in its JSON schema generation capabilities which were meant to cater to OpenAI restrictions around JSON schema. This PR reinstates the original schema generation behaviour by applying a "schema transformer" on the individual IChatClient implementation.