### PR TITLE
Only reference package Microsoft.Bcl.AsyncInterfaces when required.

### DIFF
--- a/src/OllamaSharp/OllamaSharp.csproj
+++ b/src/OllamaSharp/OllamaSharp.csproj
@@ -42,8 +42,11 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
 		<PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
According to the [package documentation](https://www.nuget.org/packages/Microsoft.Bcl.AsyncInterfaces/9.0.5#readme-body-tab):

> This library is not necessary nor recommended when targeting versions of
> .NET that include the relevant support.

According to [Microsoft Learn](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.iasyncenumerable-1), `IAsyncEnumerable<T>` is included in .NET Core 3 and .NET Standard 2.1. So this package is only needed for .NET Standard 2.0.