### PR TITLE
Updates ModelContextProtocol Nuget to version 0.2.0-preview.3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,24 +3,24 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-      <PackageVersion Include="coverlet.collector" Version="6.0.3" />
-      <PackageVersion Include="coverlet.collector" Version="6.0.3" />
-      <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0" />
-      <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.12.0" />
-      <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
-      <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="9.5.0" />
-      <PackageVersion Include="Microsoft.Extensions.AI" Version="9.5.0" />
-      <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="9.0.2" />
-      <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-      <PackageVersion Include="Moq" Version="4.20.72" />
-      <PackageVersion Include="NUnit.Analyzers" Version="4.5.0" />
-      <PackageVersion Include="NUnit" Version="4.3.2" />
-      <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
-      <PackageVersion Include="Shouldly" Version="4.3.0" />
-      <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.7" />
-      <PackageVersion Include="Spectre.Console.ImageSharp" Version="0.49.1" />
-      <PackageVersion Include="Spectre.Console" Version="0.49.1" />
-      <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
-      <PackageVersion Include="ModelContextProtocol" Version="0.1.0-preview.13" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.3" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.3" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.12.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
+    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="9.5.0" />
+    <PackageVersion Include="Microsoft.Extensions.AI" Version="9.5.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.5.0" />
+    <PackageVersion Include="NUnit" Version="4.3.2" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageVersion Include="Shouldly" Version="4.3.0" />
+    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.7" />
+    <PackageVersion Include="Spectre.Console.ImageSharp" Version="0.49.1" />
+    <PackageVersion Include="Spectre.Console" Version="0.49.1" />
+    <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
+    <PackageVersion Include="ModelContextProtocol" Version="0.2.0-preview.3" />
   </ItemGroup>
 </Project>

--- a/src/OllamaSharp.ModelContextProtocol/McpClientOptions.cs
+++ b/src/OllamaSharp.ModelContextProtocol/McpClientOptions.cs
@@ -1,6 +1,6 @@
 using Microsoft.Extensions.Logging;
-using ModelContextProtocol.Protocol.Transport;
-using ModelContextProtocol.Protocol.Types;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
 using OllamaSharp.ModelContextProtocol.Server;
 
 namespace OllamaSharp.ModelContextProtocol;

--- a/src/OllamaSharp.ModelContextProtocol/Tools.cs
+++ b/src/OllamaSharp.ModelContextProtocol/Tools.cs
@@ -3,7 +3,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using ModelContextProtocol.Protocol.Transport;
+using ModelContextProtocol.Client;
 using OllamaSharp.ModelContextProtocol.Server;
 using ModelContextProtocolClient = ModelContextProtocol.Client;
 
@@ -82,7 +82,7 @@ public static class Tools
 			var client = await ModelContextProtocolClient.McpClientFactory.CreateAsync(clientTransport, options, loggerFactory);
 			foreach (var tool in await ModelContextProtocolClient.McpClientExtensions.ListToolsAsync(client))
 			{
-				result.Add(new McpClientTool(tool, client));
+				result.Add(new Server.McpClientTool(tool, client));
 			}
 		}
 

--- a/tests/OllamaSharp.ModelContextProtocol.Tests/Infrastructure/TestClientTransport.cs
+++ b/tests/OllamaSharp.ModelContextProtocol.Tests/Infrastructure/TestClientTransport.cs
@@ -1,6 +1,6 @@
 using System.Threading.Channels;
-using ModelContextProtocol.Protocol.Messages;
-using ModelContextProtocol.Protocol.Transport;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
 
 namespace OllamaSharp.ModelContextProtocol.Tests.Infrastructure;
 

--- a/tests/OllamaSharp.ModelContextProtocol.Tests/Infrastructure/TestTransport.cs
+++ b/tests/OllamaSharp.ModelContextProtocol.Tests/Infrastructure/TestTransport.cs
@@ -1,8 +1,6 @@
 using System.Text.Json;
 using System.Threading.Channels;
-using ModelContextProtocol.Protocol.Messages;
-using ModelContextProtocol.Protocol.Transport;
-using ModelContextProtocol.Protocol.Types;
+using ModelContextProtocol.Protocol;
 
 namespace OllamaSharp.ModelContextProtocol.Tests.Infrastructure;
 


### PR DESCRIPTION
Updates ModelContextProtocol Nuget package to version 0.2.0-preview.3. Tests that I could run without a locally running instance of Ollama or the testing model all passed. No changes to any code except for updating Using statements and fixing a type name conflict. Projects running MCP Nuget version 0.2.0 or higher will experience errors when using OllamaSharp.ModelContextProtocol because of breaking changes. 