### PR TITLE
Improve thinking support on Chats

### DIFF
--- a/demo/Demos/ChatConsole.cs
+++ b/demo/Demos/ChatConsole.cs
@@ -23,7 +23,8 @@ public class ChatConsole(IOllamaApiClient ollama) : OllamaConsole(ollama)
 				AnsiConsole.MarkupLine($"You are talking to [{AccentTextColor}]{Ollama.SelectedModel}[/] now.");
 				WriteChatInstructionHint();
 
-				var chat = new Chat(Ollama, systemPrompt);
+				var chat = new Chat(Ollama, systemPrompt) { Think = Think };
+				chat.OnThink = (thoughts) => AnsiConsole.MarkupInterpolated($"[{AiThinkTextColor}]{thoughts}[/]");
 
 				string message;
 
@@ -36,6 +37,14 @@ public class ChatConsole(IOllamaApiClient ollama) : OllamaConsole(ollama)
 					{
 						keepChatting = false;
 						break;
+					}
+
+					if (message.Equals(TOGGLETHINK_COMMAND, StringComparison.OrdinalIgnoreCase))
+					{
+						ToggleThink();
+						keepChatting = true;
+						chat.Think = Think;
+						continue;
 					}
 
 					if (message.Equals(START_NEW_COMMAND, StringComparison.OrdinalIgnoreCase))

--- a/demo/Demos/ImageChatConsole.cs
+++ b/demo/Demos/ImageChatConsole.cs
@@ -25,7 +25,8 @@ public partial class ImageChatConsole(IOllamaApiClient ollama) : OllamaConsole(o
 				AnsiConsole.MarkupLine($"[{HintTextColor}]To send an image, simply enter its full filename like \"[{AccentTextColor}]c:/image.jpg[/]\"[/]");
 				WriteChatInstructionHint();
 
-				var chat = new Chat(Ollama, systemPrompt);
+				var chat = new Chat(Ollama, systemPrompt) { Think = Think };
+				chat.OnThink = (thoughts) => AnsiConsole.MarkupInterpolated($"[{AiThinkTextColor}]{thoughts}[/]");
 
 				string message;
 
@@ -38,6 +39,14 @@ public partial class ImageChatConsole(IOllamaApiClient ollama) : OllamaConsole(o
 					{
 						keepChatting = false;
 						break;
+					}
+
+					if (message.Equals(TOGGLETHINK_COMMAND, StringComparison.OrdinalIgnoreCase))
+					{
+						ToggleThink();
+						keepChatting = true;
+						chat.Think = Think;
+						continue;
 					}
 
 					if (message.Equals(START_NEW_COMMAND, StringComparison.OrdinalIgnoreCase))

--- a/demo/Demos/ToolConsole.cs
+++ b/demo/Demos/ToolConsole.cs
@@ -38,7 +38,8 @@ public class ToolConsole(IOllamaApiClient ollama) : OllamaConsole(ollama)
 				}
 				AnsiConsole.MarkupLine($"[{HintTextColor}]Enter [{AccentTextColor}]{LIST_TOOLS_COMMAND}[/] to list all available tools.[/]");
 
-				var chat = new Chat(Ollama, systemPrompt);
+				var chat = new Chat(Ollama, systemPrompt) { Think = Think };
+				chat.OnThink = (thoughts) => AnsiConsole.MarkupInterpolated($"[{AiThinkTextColor}]{thoughts}[/]");
 
 				string message;
 
@@ -51,6 +52,14 @@ public class ToolConsole(IOllamaApiClient ollama) : OllamaConsole(ollama)
 					{
 						keepChatting = false;
 						break;
+					}
+
+					if (message.Equals(TOGGLETHINK_COMMAND, StringComparison.OrdinalIgnoreCase))
+					{
+						ToggleThink();
+						keepChatting = true;
+						chat.Think = Think;
+						continue;
 					}
 
 					if (message.Equals(START_NEW_COMMAND, StringComparison.OrdinalIgnoreCase))

--- a/demo/OllamaConsole.cs
+++ b/demo/OllamaConsole.cs
@@ -19,6 +19,7 @@ public abstract class OllamaConsole(IOllamaApiClient ollama)
 	public static string ErrorTextColor { get; } = "red";
 
 	public static string AiTextColor { get; } = "cyan";
+	public static string AiThinkTextColor { get; } = "magenta";
 
 	public static string START_NEW_COMMAND { get; } = "/new";
 	public static string USE_MCP_SERVER_COMMAND { get; } = "/mcp";
@@ -26,7 +27,11 @@ public abstract class OllamaConsole(IOllamaApiClient ollama)
 
 	public static string EXIT_COMMAND { get; } = "/exit";
 
+	public static string TOGGLETHINK_COMMAND { get; } = "/togglethink";
+
 	public IOllamaApiClient Ollama { get; } = ollama ?? throw new ArgumentNullException(nameof(ollama));
+
+	public bool? Think { get; private set; }
 
 	public abstract Task Run();
 
@@ -69,6 +74,14 @@ public abstract class OllamaConsole(IOllamaApiClient ollama)
 	{
 		AnsiConsole.MarkupLine($"[{HintTextColor}]Enter [{AccentTextColor}]{START_NEW_COMMAND}[/] to start over or [{AccentTextColor}]{EXIT_COMMAND}[/] to leave.[/]");
 		AnsiConsole.MarkupLine($"[{HintTextColor}]Begin with [{AccentTextColor}]{Markup.Escape(MULTILINE_OPEN.ToString())}[/] to start multiline input. Sumbmit it by ending with [{AccentTextColor}]{Markup.Escape(MULTILINE_CLOSE.ToString())}[/].[/]");
+		AnsiConsole.MarkupLine($"[{HintTextColor}]Think mode is [{AccentTextColor}]{Think?.ToString().ToLower() ?? "(null)"}[/]. Type [{AccentTextColor}]{TOGGLETHINK_COMMAND}[/] to change.[/]");
+	}
+
+	internal void ToggleThink()
+	{ 
+		// null -> false -> true -> null -> ...
+		Think = Think == null ? false : (Think == false ? true : (Think == true ? null : false));
+		AnsiConsole.MarkupLine($"[{HintTextColor}]Think mode is [{AccentTextColor}]{Think?.ToString().ToLower() ?? "(null)"}[/].[/]");
 	}
 
 	protected async Task<string> SelectModel(string prompt, string additionalInformation = "")

--- a/src/OllamaSharp/Chat.cs
+++ b/src/OllamaSharp/Chat.cs
@@ -69,6 +69,12 @@ public class Chat
 	/// </summary>
 	public bool? Think { get; set; }
 
+
+	/// <summary>
+	/// Gets or sets an action that is called when the AI model is thinking and Think is set to true.
+	/// </summary>
+	public Action<string>? OnThink { get; set; }
+
 	/// <summary>
 	/// Initializes a new instance of the <see cref="Chat"/> class.
 	/// This basic constructor sets up the chat without a predefined system prompt.
@@ -424,7 +430,12 @@ public class Chat
 
 			messageBuilder.Append(answer);
 
-			yield return answer.Message.Content ?? string.Empty;
+			// yield the message content or call the delegate to handle thinking
+			var isThinking = Think == true && !string.IsNullOrEmpty(answer.Message.Thinking);
+			if (isThinking)
+				OnThink?.Invoke(answer.Message.Thinking!);
+			else
+				yield return answer.Message.Content ?? string.Empty;
 		}
 
 		if (messageBuilder.HasValue)

--- a/src/OllamaSharp/Models/Chat/MessageBuilder.cs
+++ b/src/OllamaSharp/Models/Chat/MessageBuilder.cs
@@ -8,6 +8,7 @@ namespace OllamaSharp.Models.Chat;
 public class MessageBuilder
 {
 	private readonly StringBuilder _contentBuilder = new();
+	private readonly StringBuilder _thinkContentBuilder = new();
 	private List<string> _images = [];
 	private List<Message.ToolCall> _toolCalls = [];
 
@@ -44,6 +45,7 @@ public class MessageBuilder
 			return;
 
 		_contentBuilder.Append(chunk.Message.Content ?? "");
+		_thinkContentBuilder.Append(chunk.Message.Thinking ?? "");
 		Role = chunk.Message.Role;
 
 		_images.AddRangeIfNotNull(chunk.Message.Images);
@@ -81,8 +83,7 @@ public class MessageBuilder
 	/// Console.WriteLine(finalMessage.Role);    // Output: Assistant
 	/// </code>
 	/// </example>
-	public Message ToMessage() =>
-		new() { Content = _contentBuilder.ToString(), Images = _images.ToArray(), Role = Role, ToolCalls = _toolCalls };
+	public Message ToMessage() => new() { Content = _contentBuilder.ToString(), Thinking = _thinkContentBuilder.ToString(), Images = _images.ToArray(), Role = Role, ToolCalls = _toolCalls };
 
 
 	/// <summary>


### PR DESCRIPTION
The `Chat` class can now yield thoughts over `OnThink(string)` when thinking is allowed (`Think=true`).

You can easily experiment with this in the console demos by using the command `/togglethink` that switches the think mode from `null` → `false` → `true` → `null` ...

![Bildschirmfoto 2025-07-04 um 09 09 02](https://github.com/user-attachments/assets/613ec0b7-7bdd-4706-9ad0-a3ef0415ebcb)
