### PR TITLE
Support for "Think" with Microsoft.Extensions.AI ChatOptions

### DIFF
--- a/src/OllamaSharp/Constants/Application.cs
+++ b/src/OllamaSharp/Constants/Application.cs
@@ -108,4 +108,5 @@ internal static class Application
 	public const string From = "from";
 	public const string Error = "error";
 	public const string Capabilities = "capabilities";
+	public const string Think = "think";
 }

--- a/src/OllamaSharp/MicrosoftAi/AbstractionMapper.cs
+++ b/src/OllamaSharp/MicrosoftAi/AbstractionMapper.cs
@@ -118,6 +118,7 @@ internal static class AbstractionMapper
 		TryAddOllamaOption<bool?>(options, OllamaOption.UseMlock, v => request.Options.UseMlock = (bool?)v);
 		TryAddOllamaOption<bool?>(options, OllamaOption.UseMmap, v => request.Options.UseMmap = (bool?)v);
 		TryAddOllamaOption<bool?>(options, OllamaOption.VocabOnly, v => request.Options.VocabOnly = (bool?)v);
+		TryAddOllamaOption<bool?>(options, OllamaOption.Think, v => request.Think = (bool?)v);
 		TryAddOption<string?>(options, Application.KeepAlive, v => request.KeepAlive = (string?)v);
 
 		return request;

--- a/src/OllamaSharp/Models/OllamaOption.cs
+++ b/src/OllamaSharp/Models/OllamaOption.cs
@@ -222,4 +222,11 @@ public class OllamaOption(string name)
 	/// (Default: False)
 	/// </summary>
 	public static OllamaOption VocabOnly { get; } = new(Application.VocabOnly);
+
+	/// <summary>
+	/// Gets or sets a value to enable or disable thinking. Use reasoning models like OpenThinker, Qwen3,
+	/// DeepSeek-R1, Phi4-Reasoning that support thinking when activating this option.
+	/// (Default: Null)
+	/// </summary>
+	public static OllamaOption Think { get; } = new(Application.Think);
 }

--- a/test/AbstractionMapperTests.cs
+++ b/test/AbstractionMapperTests.cs
@@ -638,7 +638,8 @@ public class AbstractionMapperTests
 				.AddOllamaOption(OllamaOption.TypicalP, 1.01f)
 				.AddOllamaOption(OllamaOption.UseMlock, false)
 				.AddOllamaOption(OllamaOption.UseMmap, true)
-				.AddOllamaOption(OllamaOption.VocabOnly, false);
+				.AddOllamaOption(OllamaOption.VocabOnly, false)
+				.AddOllamaOption(OllamaOption.Think, false);
 
 			var ollamaRequest = AbstractionMapper.ToOllamaSharpChatRequest([], options, stream: true, JsonSerializerOptions.Default);
 
@@ -673,6 +674,7 @@ public class AbstractionMapperTests
 			ollamaRequest.Options.UseMlock.ShouldBe(false);
 			ollamaRequest.Options.UseMmap.ShouldBe(true);
 			ollamaRequest.Options.VocabOnly.ShouldBe(false);
+			ollamaRequest.Think.ShouldBe(false);
 		}
 	}
 


### PR DESCRIPTION
Usage:
```csharp
var chatClient = new OllamaApiClient(new OllamaApiClient.Configuration()
{
	Uri = new Uri("http://localhost:11434"),
	Model = "qwen3:1.7b"
});
var options = new ChatOptions();
options.AddOllamaOption(OllamaOption.Think, false);//Disable think
var response = await chatClient.GetResponseAsync("Why is the sky blue?", options, CancellationToken.None);

```