### PR TITLE
Add boolean parameter handling in ToolSourceGenerator

### DIFF
--- a/src/SourceGenerators/ToolSourceGenerator.cs
+++ b/src/SourceGenerators/ToolSourceGenerator.cs
@@ -37,7 +37,7 @@ public class ToolSourceGenerator : IIncrementalGenerator
 		foreach (var methodSymbol in methods)
 		{
 			var containingNamespace = methodSymbol.ContainingType.ContainingNamespace?.ToString() ?? "";
-			
+
 			// handle the default namespace which is "<global namespace>"
 			if (containingNamespace.StartsWith("<global"))
 				containingNamespace = string.Empty;
@@ -218,6 +218,21 @@ public class ToolSourceGenerator : IIncrementalGenerator
 				else
 				{
 					paramLines.Add($@"            {pType} {safeName} = ({pType})Enum.Parse(typeof({pType}), args[""{pName}""]?.ToString() ?? """", ignoreCase: true);");
+				}
+			}
+			else if (pType.StartsWith("bool", StringComparison.OrdinalIgnoreCase))
+			{
+				if (!p.IsOptional)
+				{
+					paramLines.Add($@"            {pType} {safeName} = ({pType})args[""{pName}""];");
+				}
+				else if (p.ExplicitDefaultValue is bool defaultBoolValue)
+				{
+					paramLines.Add($@"            {pType} {safeName} = args.ContainsKey(""{pName}"") ? ({pType})args[""{pName}""] : {defaultBoolValue.ToString().ToLowerInvariant()};");
+				}
+				else
+				{
+					paramLines.Add($@"            {pType} {safeName} = args.ContainsKey(""{pName}"") ? ({pType})args[""{pName}""] : null;");
 				}
 			}
 			else if (IsNumericType(tName))

--- a/test/SourceGenerators/ToolSourceGeneratorTests.cs
+++ b/test/SourceGenerators/ToolSourceGeneratorTests.cs
@@ -120,6 +120,47 @@ public class Test
 		}
 
 		[Test]
+		public void Supports_Booleans()
+		{
+			var code = """
+namespace TestNamespace;
+public class Test
+{
+    /// <summary>
+    /// Tests boolean parameter handling.
+    /// </summary>
+    /// <param name="required">A required boolean parameter</param>
+    /// <param name="nullableRequired">A required nullable boolean</param>
+    /// <param name="optionalTrue">An optional boolean with true default</param>
+    /// <param name="nullableOptionalNull">An optional nullable boolean with null default</param>
+    /// <param name="nullableOptionalTrue">An optional nullable boolean with true default</param>
+    [OllamaTool]
+    public static string TestBooleans(
+        bool required, 
+        bool? nullableRequired,
+        bool optionalTrue = true, 
+        bool? nullableOptionalNull = null,
+        bool? nullableOptionalTrue = true) => "test";
+}
+""";
+
+			var result = RunGenerator(code);
+
+			result.GeneratedTool.Function.Parameters.Required.ShouldBe(["required", "nullableRequired"], ignoreOrder: true);
+			result.GeneratedTool.Function.Parameters.Properties["required"].Description.ShouldBe("A required boolean parameter");
+			result.GeneratedTool.Function.Parameters.Properties["optionalTrue"].Description.ShouldBe("An optional boolean with true default");
+			result.GeneratedTool.Function.Parameters.Properties["nullableRequired"].Description.ShouldBe("A required nullable boolean");
+			result.GeneratedTool.Function.Parameters.Properties["nullableOptionalNull"].Description.ShouldBe("An optional nullable boolean with null default");
+			result.GeneratedTool.Function.Parameters.Properties["nullableOptionalTrue"].Description.ShouldBe("An optional nullable boolean with true default");
+
+			result.GeneratedCode.ShouldContain("bool required = (bool)args[\"required\"];");
+			result.GeneratedCode.ShouldContain("bool? nullableRequired = (bool?)args[\"nullableRequired\"];");
+			result.GeneratedCode.ShouldContain("bool optionalTrue = args.ContainsKey(\"optionalTrue\") ? (bool)args[\"optionalTrue\"] : true;");
+			result.GeneratedCode.ShouldContain("bool? nullableOptionalNull = args.ContainsKey(\"nullableOptionalNull\") ? (bool?)args[\"nullableOptionalNull\"] : null;");
+			result.GeneratedCode.ShouldContain("bool? nullableOptionalTrue = args.ContainsKey(\"nullableOptionalTrue\") ? (bool?)args[\"nullableOptionalTrue\"] : true;");
+		}
+
+		[Test]
 		public void Supports_String_And_Number_Arguments()
 		{
 			var code = """


### PR DESCRIPTION
Updated the `ToolSourceGenerator` to support boolean parameters and add corresponding test coverage. The generator was generating invalid code for optional bools because `IParameterSymbol.ExplicitDefaultValue` returns "True"/"False" (capitalized), but C# boolean literals/langwords require lowercase "true"/"false"

<img width="423" height="97" alt="Tool" src="https://github.com/user-attachments/assets/502845ba-05ee-47f3-bc7c-5d6bd56829f7" />

Generated:
<img width="527" height="138" alt="toolgen" src="https://github.com/user-attachments/assets/6b1bf0b6-553e-4f24-a6bc-c10aee70247d" />


### Boolean parameter handling:

* `src/SourceGenerators/ToolSourceGenerator.cs`: Updated the `GenerateInvokeMethodCode` method to handle boolean parameters, including required, optional, and nullable booleans with default values.

### Test coverage:

* `test/SourceGenerators/ToolSourceGeneratorTests.cs`: Added a new test, `Supports_Booleans`, to verify the handling of boolean parameters in generated code.