### PR TITLE
Use source-generation JSON for NativeAOT support

### DIFF
--- a/src/OllamaSharp/Models/JsonSourceGenerationContext.cs
+++ b/src/OllamaSharp/Models/JsonSourceGenerationContext.cs
@@ -1,0 +1,44 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using OllamaSharp.MicrosoftAi;
+using OllamaSharp.Models.Chat;
+
+namespace OllamaSharp.Models;
+
+/// <summary>
+/// JsonSourceGenerationContext
+/// </summary>
+[JsonSourceGenerationOptions(WriteIndented = true)]
+[JsonSerializable(typeof(ErrorResponse))]
+[JsonSerializable(typeof(DeleteModelRequest))]
+[JsonSerializable(typeof(ListModelsResponse))]
+[JsonSerializable(typeof(ListRunningModelsResponse))]
+[JsonSerializable(typeof(EmbedRequest))]
+[JsonSerializable(typeof(EmbedResponse))]
+[JsonSerializable(typeof(ShowModelRequest))]
+[JsonSerializable(typeof(ShowModelResponse))]
+[JsonSerializable(typeof(CreateModelRequest))]
+[JsonSerializable(typeof(CreateModelResponse))]
+[JsonSerializable(typeof(PullModelRequest))]
+[JsonSerializable(typeof(PullModelResponse))]
+[JsonSerializable(typeof(PushModelRequest))]
+[JsonSerializable(typeof(PushModelResponse))]
+[JsonSerializable(typeof(GenerateDoneResponseStream))]
+[JsonSerializable(typeof(GenerateResponseStream))]
+[JsonSerializable(typeof(GenerateRequest))]
+[JsonSerializable(typeof(Message.ToolCall))]
+[JsonSerializable(typeof(Message.Function), TypeInfoPropertyName = "MessageFunction")]
+[JsonSerializable(typeof(Tool))]
+[JsonSerializable(typeof(Function))]
+[JsonSerializable(typeof(Parameters))]
+[JsonSerializable(typeof(Property))]
+[JsonSerializable(typeof(JsonNode))]
+[JsonSerializable(typeof(JsonElement))]
+[JsonSerializable(typeof(OllamaFunctionResultContent))]
+[JsonSerializable(typeof(ChatRequest))]
+[JsonSerializable(typeof(ChatDoneResponseStream))]
+[JsonSerializable(typeof(ChatResponseStream))]
+internal partial class JsonSourceGenerationContext : JsonSerializerContext
+{
+}

--- a/src/OllamaSharp/OllamaApiClient.cs
+++ b/src/OllamaSharp/OllamaApiClient.cs
@@ -27,12 +27,12 @@ public class OllamaApiClient : IOllamaApiClient, IChatClient, IEmbeddingGenerato
 	/// <summary>
 	/// Gets the serializer options for outgoing web requests like Post or Delete.
 	/// </summary>
-	public JsonSerializerOptions OutgoingJsonSerializerOptions { get; } = new() { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
+	public JsonSerializerOptions OutgoingJsonSerializerOptions { get; } = new() { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping, TypeInfoResolver = JsonSourceGenerationContext.Default };
 
 	/// <summary>
 	/// Gets the serializer options used for deserializing HTTP responses.
 	/// </summary>
-	public JsonSerializerOptions IncomingJsonSerializerOptions { get; } = new();
+	public JsonSerializerOptions IncomingJsonSerializerOptions { get; } = new() { TypeInfoResolver = JsonSourceGenerationContext.Default };
 
 	/// <summary>
 	/// Gets the current configuration of the API client.


### PR DESCRIPTION
Currently, OllamaSharp encounters compatibility issues with System.Text.Json's reflection-based serialization when compiled with NativeAOT.

This PR refactors the JSON serialization and deserialization in the project to use source-generation mode. The primary goal is to enable full compatibility with NativeAOT