### PR TITLE
Update MEAI to 9.8.0 + remove vulnerable + address warnings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -59,6 +59,10 @@ dotnet_diagnostic.IDE0005.severity = warning      # Using directive is unnecessa
 dotnet_diagnostic.IDE0055.severity = error        # formatting rules
 dotnet_diagnostic.IDE1006.severity = warning      # naming rules
 dotnet_diagnostic.IDE0150.severity = none 		  # Null check can be clarified
+dotnet_diagnostic.IDE0011.severity = none		  # Add braces to 'if' statement
+dotnet_diagnostic.IDE2000.severity = suggestion   # Avoid multiple blank lines
+dotnet_diagnostic.IDE2002.severity = suggestion   # Consecutive braces must not have blank line between them
+dotnet_diagnostic.IDE0055.severity = suggestion   # Fix formatting
 
 dotnet_diagnostic.BC42104.severity = error # BC42104: Variable is used before it has been assigned a value
 dotnet_diagnostic.BC42358.severity = error # because this call is not awaited, execution of the current method continues before the call is completed

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,22 +3,21 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="coverlet.collector" Version="6.0.3" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.12.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
-    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="9.7.1" />
-    <PackageVersion Include="Microsoft.Extensions.AI" Version="9.7.1" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="9.8.0" />
+    <PackageVersion Include="Microsoft.Extensions.AI" Version="9.8.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="9.0.8" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.9.2" />
     <PackageVersion Include="NUnit" Version="4.3.2" />
     <PackageVersion Include="NUnit3TestAdapter" Version="5.0.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
-    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.10" />
+    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.11" />
     <PackageVersion Include="Spectre.Console.ImageSharp" Version="0.50.0" />
     <PackageVersion Include="Spectre.Console" Version="0.50.0" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.3" />

--- a/src/OllamaSharp.ModelContextProtocol/Server/McpClientTool.cs
+++ b/src/OllamaSharp.ModelContextProtocol/Server/McpClientTool.cs
@@ -47,7 +47,7 @@ public class McpClientTool : OllamaSharp.Models.Chat.Tool, OllamaSharp.Tools.IAs
 	/// <inheritdoc />
 	public async Task<object?> InvokeMethodAsync(IDictionary<string, object?>? args)
 	{
-		var arguments = args?.ToDictionary(a => a.Key, a => (object?) (a.Value ?? string.Empty)) ?? [];
+		var arguments = args?.ToDictionary(a => a.Key, a => (object?)(a.Value ?? string.Empty)) ?? [];
 
 		try
 		{


### PR DESCRIPTION
# Motivation and Context

- Update to latest Microsoft.Extensions.AI package version 9.8.0 ahead of Semantic Kernel update.
- This pull request updates several other August NuGet package versions to their latest releases
- Updates a vulnerable package for `SixLabors.ImageSharp`.
- Update editor rules to ensure some formatting rules to be just suggestions instead of errors.
- Fix a duplicate package for `coverlet.colletor`.