### PR TITLE
Forwarding Error content in McpClientTool

### DIFF
--- a/src/OllamaSharp.ModelContextProtocol/Server/McpClientTool.cs
+++ b/src/OllamaSharp.ModelContextProtocol/Server/McpClientTool.cs
@@ -52,11 +52,12 @@ public class McpClientTool : OllamaSharp.Models.Chat.Tool, OllamaSharp.Tools.IAs
 		try
 		{
 			var toolresult = await _client.CallToolAsync(Function!.Name!, arguments);
+			var textContent = string.Join('\n', toolresult.Content.Select(c => c.Text));
 
 			if (toolresult.IsError)
-				return null;
+				return "Error: " + textContent;
 
-			return string.Join('\n', toolresult.Content.Select(c => c.Text));
+			return textContent;
 		}
 		catch (Exception ex)
 		{


### PR DESCRIPTION
When Invoking an McpMcpServerTool function, it the underlining method throws an exception, the ToolInvoker simply returns null, this often causes the model to allucinate, thinking that the function executed correctly.

Error responses from CallToolAsync now return the error content prefixed with 'Error:' instead of null, providing more informative feedback to callers.

I'm not sure wether simply prefixing "Error" to the result is the best way to go about doing this, but at least the content in the CallToolResponse.Content is not lost.

We could instead add an IsError property to the ToolResult class and handle it differently in Chat.cs (i.e. new Message(ChatRole.Tool, "Tool: .. Error:...")) but I think that would be a more invasive change and probably would require changes to the IInvokaboleToll interface.
 