### PR TITLE
Fix tests Allows_Line_Breaks_In_Summary and ListRunningModels.

### DIFF
--- a/src/SourceGenerators/ToolSourceGenerator.cs
+++ b/src/SourceGenerators/ToolSourceGenerator.cs
@@ -359,7 +359,7 @@ using System.Threading.Tasks;
 ";
 	}
 
-	private static string Escape(string input) => input.Replace("\\", "\\\\").Replace("\"", "\\\"");
+	private static string Escape(string input) => input.Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("\n", " ").Replace("\r", " ").Replace("  ", " ");
 
 	private static string ToValidIdentifier(string name) => SyntaxFacts.GetKeywordKind(name) != SyntaxKind.None ? "_" + name : name;
 }

--- a/test/FunctionalTests/OllamaApiClientTests.cs
+++ b/test/FunctionalTests/OllamaApiClientTests.cs
@@ -130,21 +130,13 @@ public class OllamaApiClientTests
 	public async Task ListRunningModels()
 	{
 		await PullIfNotExists(_model);
-		var backgroundTask = Task.Run(async () =>
-		{
-			var generate = _client
-				.GenerateAsync(new GenerateRequest { Model = _model, Prompt = "Write a long song." })
-				.ToListAsync();
 
-			await Task.Yield();
+		// Make sure the model is running.
+		_ = await _client.GenerateAsync(new GenerateRequest { Model = _model, Prompt = "Please say 'hello'." })
+						 .ToListAsync();
 
-			await generate;
-		});
+		var models = (await _client.ListRunningModelsAsync()).ToList();
 
-		var modelsTask = _client.ListRunningModelsAsync();
-		await Task.WhenAll(backgroundTask, modelsTask);
-
-		var models = modelsTask.Result.ToList();
 		models.ShouldNotBeEmpty();
 		models.ShouldContain(m => m.Name == _model);
 	}


### PR DESCRIPTION
For `Allows_Line_Breaks_In_Summary`, the new lines were ending up in an unescaped strings. So I replace the newlines with spaces to make the test pass.

For `ListRunningModels`, there was race condition. The call to `GenerateAsync` and `ListRunningModelsAsync` were running at the same time, so usually the call to `ListRunningModelsAsync` returned no running models the first time the test was run. When the test was run a second time, the model would already be running and the test would pass. I fixed this by ensure that the call to `GenerateAsync` completes before calling `ListRunningModelsAsync`. While I was at it, I made the prompt generate a smaller number of tokens so the test completes faster.