### PR TITLE
Update ME.AI packages to 9.9.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,10 +7,10 @@
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.12.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
-    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="9.8.0" />
-    <PackageVersion Include="Microsoft.Extensions.AI" Version="9.8.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="9.9.0" />
+    <PackageVersion Include="Microsoft.Extensions.AI" Version="9.9.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="9.0.9" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.9.2" />


### PR DESCRIPTION
Updating packages to latest Microsoft Extensions AI 9.9.0

> [!NOTE]
> I noticed some pontentially unrelated issues running the `Allows_Line_Breaks_In_Summary` UnitTest which seems related to Windows environment.
> 
> Pointing out to the `GenerateToolClassCode`, when it escapes `methodSummary` it does not work for the `\r` breaks and gives a compilation error.

Just realized there's a PR attemping to address the issue already in the queue.

- #309