### PR TITLE
Improve containing namespace code

### DIFF
--- a/src/SourceGenerators/ToolSourceGenerator.cs
+++ b/src/SourceGenerators/ToolSourceGenerator.cs
@@ -36,11 +36,9 @@ public class ToolSourceGenerator : IIncrementalGenerator
 	{
 		foreach (var methodSymbol in methods)
 		{
-			var containingNamespace = methodSymbol.ContainingType.ContainingNamespace?.ToString() ?? "";
-
-			// handle the default namespace which is "<global namespace>"
-			if (containingNamespace.StartsWith("<global"))
-				containingNamespace = string.Empty;
+			var containingNamespace = (methodSymbol.ContainingNamespace is null || methodSymbol.ContainingNamespace.IsGlobalNamespace)
+				? string.Empty
+				: methodSymbol.ContainingNamespace.ToString();
 
 			var className = methodSymbol.ContainingType.Name;
 			var toolClassName = methodSymbol.Name + "Tool";


### PR DESCRIPTION
I found some hacky code in the source generator to check if the containing namespace is the global namespace, so I updated it to use the official `IsGlobalNamespace` API. It is also unnecessary to use `.ContainingType.ContainingNamespace` since `.ContainingNamespace` is the same.