### PR TITLE
Fix display issue with package readme on nuget.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-<a href="https://www.nuget.org/packages/OllamaSharp"><img src="https://img.shields.io/nuget/v/OllamaSharp" alt="nuget version"></a>
-<a href="https://www.nuget.org/packages/OllamaSharp"><img src="https://img.shields.io/nuget/dt/OllamaSharp.svg" alt="nuget downloads"></a>
-<a href="https://awaescher.github.io/OllamaSharp"><img src="https://img.shields.io/badge/api_docs-8A2BE2" alt="Api docs"></a>
+[![nuget version](https://img.shields.io/nuget/v/OllamaSharp)](https://www.nuget.org/packages/OllamaSharp)
+[![nuget downloads](https://img.shields.io/nuget/dt/OllamaSharp.svg)](https://www.nuget.org/packages/OllamaSharp)
+[![Api docs](https://img.shields.io/badge/api_docs-8A2BE2)](https://awaescher.github.io/OllamaSharp)
 
 # OllamaSharp 🦙
 


### PR DESCRIPTION
Change the format of the badges to markdown style instead of HTML to fix the display issue at https://www.nuget.org/packages/OllamaSharp/

<img width="1082" height="778" alt="image" src="https://github.com/user-attachments/assets/3f65acee-04f8-44cb-9155-b3199974c5f4" />
