### PR TITLE
Fix null reference exception in AbstractionMapper.ToChatResponseUpdate

### DIFF
--- a/src/OllamaSharp/MicrosoftAi/AbstractionMapper.cs
+++ b/src/OllamaSharp/MicrosoftAi/AbstractionMapper.cs
@@ -358,8 +358,8 @@ internal static class AbstractionMapper
 				ModelId = done.Model
 			};
 		}
-		
-		return new ChatResponseUpdate(ToAbstractionRole(response?.Message.Role), contents)
+
+		return new ChatResponseUpdate(ToAbstractionRole(response?.Message?.Role), contents)
 		{
 			// no need to set "Contents" as we set the text
 			CreatedAt = response?.CreatedAt,


### PR DESCRIPTION
## Description
This PR fixes a NullReferenceException that occurs in `AbstractionMapper.ToChatResponseUpdate` method when processing streaming responses.
 
## Problem
When the Ollama API returns a response where `response` or `response.Message` is null, the current implementation throws a NullReferenceException at:
```csharp
ToAbstractionRole(response.Message.Role)
 ```
## Solution
 
Added null-safe navigation operators to handle null responses gracefully:
ToAbstractionRole(response?.Message?.Role)
 
## Testing
 
- Tested with various streaming scenarios including empty responses
- No breaking changes introduced
 
## Related Issues
 
This issue was discovered while using OllamaSharp with Microsoft.Extensions.AI in production environments where occasional null responses from the Ollama API caused application crashes.