### PR TITLE
Fix ToolSourceGenerator generated code throwing KeyNotFoundException

### DIFF
--- a/src/SourceGenerators/ToolSourceGenerator.cs
+++ b/src/SourceGenerators/ToolSourceGenerator.cs
@@ -247,7 +247,7 @@ public class ToolSourceGenerator : IIncrementalGenerator
 					if (p.IsOptional)
 					{
 						var def = p.ExplicitDefaultValue is null ? "\"\"" : $"\"{p.ExplicitDefaultValue}\"";
-						paramLines.Add($@"            {pType} {safeName} = ({pType}?)args[""{pName}""] ?? {def};");
+						paramLines.Add($@"            {pType} {safeName} = ({pType}?)(args.ContainsKey(""{pName}"") ? args[""{pName}""] : null) ?? {def};");
 					}
 					else
 					{
@@ -257,7 +257,7 @@ public class ToolSourceGenerator : IIncrementalGenerator
 				else
 				{
 					if (p.IsOptional && p.ExplicitDefaultValue != null)
-						paramLines.Add($@"            {pType} {safeName} = ({pType}?)args[""{pName}""] ?? ({pType}){p.ExplicitDefaultValue};");
+						paramLines.Add($@"            {pType} {safeName} = ({pType}?)(args.ContainsKey(""{pName}"") ? args[""{pName}""] : null) ?? ({pType}){p.ExplicitDefaultValue};");
 					else
 						paramLines.Add($@"            {pType} {safeName} = ({pType}?)args[""{pName}""];");
 				}


### PR DESCRIPTION
Currently, a function with an optional string argument like
```csharp
[OllamaTool]
public static string AddReminder(string content = "") {...}
```
will be converted by ToolSourceGenerator into:
```csharp
public object? InvokeMethod(IDictionary<string, object?>? args)
{
    if (args == null) args = new Dictionary<string, object?>();
    string content = (string?)args["content"] ?? "";
    var result = Project.AddReminder(content);
    return result;
}
```

However, this is incorrect, since if the model doesn't provide the "content" argument (since it is optional), `args["content"]` will throw `KeyNotFoundException`.

This PR addresses this issue by checking if the parameter name is in the dictionary first -- similar to how numeric parameters are handled.