### PR TITLE
Improve `ToValidIdentifier`

### DIFF
--- a/src/SourceGenerators/ToolSourceGenerator.cs
+++ b/src/SourceGenerators/ToolSourceGenerator.cs
@@ -363,5 +363,5 @@ using System.Threading.Tasks;
 
 	private static string Escape(string input) => input.Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("\n", " ").Replace("\r", " ").Replace("  ", " ");
 
-	private static string ToValidIdentifier(string name) => SyntaxFacts.GetKeywordKind(name) != SyntaxKind.None ? "_" + name : name;
+	private static string ToValidIdentifier(string name) => SyntaxFacts.GetKeywordKind(name) != SyntaxKind.None ? "@" + name : name;
 }


### PR DESCRIPTION
Replaces #350.

I decided the performance improvements from that PR are not worth the added complexity.

I took out one small improvement from that PR though: use `@` to escape identifiers, not `_`. This will avoid collisions with identifiers starting with `_`.